### PR TITLE
feat: Implement Auto Best Rocket Launcher with configuration options and behavior

### DIFF
--- a/src/main/java/com/deeme/behaviours/bestammo/BestAmmoConfig.java
+++ b/src/main/java/com/deeme/behaviours/bestammo/BestAmmoConfig.java
@@ -32,7 +32,7 @@ public class BestAmmoConfig {
             BehaviourOptionsEnum.RESPECT_RSB_TAG, BehaviourOptionsEnum.RESPECT_NPC_AMMO,
             BehaviourOptionsEnum.REPLACE_AMMO_KEY, BehaviourOptionsEnum.CHANGE_AMMO_DIRECTLY);
 
-    @Option("general.always_use_bellow_hp")
+    @Option("general.always_use_below_hp")
     @Percentage
     public double alwaysUseBellowHp = 0;
 }

--- a/src/main/java/com/deeme/behaviours/bestammo/BestAmmoConfig.java
+++ b/src/main/java/com/deeme/behaviours/bestammo/BestAmmoConfig.java
@@ -2,9 +2,7 @@ package com.deeme.behaviours.bestammo;
 
 import java.util.EnumSet;
 import java.util.Set;
-
-import com.deemeplus.suppliers.LaserSupplier;
-
+import com.deeme.types.suppliers.LaserSupplier;
 import eu.darkbot.api.config.annotations.Configuration;
 import eu.darkbot.api.config.annotations.Dropdown;
 import eu.darkbot.api.config.annotations.Option;
@@ -31,9 +29,8 @@ public class BestAmmoConfig {
     @Option("general.options")
     @Dropdown(multi = true)
     public Set<BehaviourOptionsEnum> optionsToUse = EnumSet.of(BehaviourOptionsEnum.VS_PLAYERS,
-            BehaviourOptionsEnum.RESPECT_RSB_TAG,
-            BehaviourOptionsEnum.RESPECT_NPC_AMMO, BehaviourOptionsEnum.REPLACE_AMMO_KEY,
-            BehaviourOptionsEnum.CHANGE_AMMO_DIRECTLY);
+            BehaviourOptionsEnum.RESPECT_RSB_TAG, BehaviourOptionsEnum.RESPECT_NPC_AMMO,
+            BehaviourOptionsEnum.REPLACE_AMMO_KEY, BehaviourOptionsEnum.CHANGE_AMMO_DIRECTLY);
 
     @Option("general.always_use_bellow_hp")
     @Percentage

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
@@ -89,11 +89,11 @@ public class AutoBestRocketLauncherDummy
         Lockable target = heroapi.getLocalTarget();
         if (target != null && target.isValid() && heroapi.isAttacking()) {
             boolean isNpc = target instanceof Npc;
-            if (hasTag(ExtraNpcFlagsEnum.BEST_AMMO)
+            if (hasTag(target, ExtraNpcFlagsEnum.BEST_AMMO)
                     || (!isNpc && hasOption(BehaviourOptionsEnum.VS_PLAYERS))
                     || (isNpc && hasOption(BehaviourOptionsEnum.ALWAYS_FOR_NPC))
                     || heroapi.getHealth().hpPercent() <= config.alwaysUseBellowHp) {
-                changeRocketLauncher(getBestRocketLauncher(isNpc));
+                changeRocketLauncher(getBestRocketLauncher(target, isNpc));
                 return;
             }
         }
@@ -109,7 +109,7 @@ public class AutoBestRocketLauncherDummy
                 .isSuccessful();
     }
 
-    private SelectableItem getBestRocketLauncher(boolean isNpc) {
+    private SelectableItem getBestRocketLauncher(Lockable target, boolean isNpc) {
         if (ableToUseInfectionAmmo(isNpc)) {
             return RocketLauncher.PIR_100;
         }
@@ -119,7 +119,7 @@ public class AutoBestRocketLauncherDummy
             return sabRocket;
         }
 
-        SelectableItem damageRocket = getDamageRocket(isNpc);
+        SelectableItem damageRocket = getDamageRocket(target, isNpc);
         if (damageRocket != null) {
             return damageRocket;
         }
@@ -142,8 +142,7 @@ public class AutoBestRocketLauncherDummy
         return null;
     }
 
-    private SelectableItem getDamageRocket(boolean isNpc) {
-        Lockable target = heroapi.getLocalTarget();
+    private SelectableItem getDamageRocket(Lockable target, boolean isNpc) {
         if (target != null && target.isValid()) {
             if (target.getHealth().getHp() > URB_100_DAMAGE_X2
                     && ableToUse(RocketLauncher.UBR_100, isNpc)) {
@@ -187,8 +186,7 @@ public class AutoBestRocketLauncherDummy
         return item.isPresent() && item.get().getQuantity() > MIN_ROCKET_AMMO;
     }
 
-    private boolean hasTag(Enum<?> tag) {
-        Lockable target = heroapi.getLocalTarget();
+    private boolean hasTag(Lockable target, Enum<?> tag) {
         return (target != null && target.isValid() && target instanceof Npc
                 && ((Npc) target).getInfo().hasExtraFlag(tag));
     }

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
@@ -110,37 +110,52 @@ public class AutoBestRocketLauncherDummy
             return RocketLauncher.PIR_100;
         }
 
-        if (this.ammoConditions.ableToUseSAB()) {
-            if (ableToUse(RocketLauncher.CBR, isNpc)) {
-                return RocketLauncher.CBR;
-            } else if (ableToUse(RocketLauncher.SAR_02, isNpc)) {
-                return RocketLauncher.SAR_02;
-            } else if (ableToUse(RocketLauncher.SAR_01, isNpc)) {
-                return RocketLauncher.SAR_01;
-            }
+        SelectableItem sabRocket = getBestSabRocket(isNpc);
+        if (sabRocket != null) {
+            return sabRocket;
         }
 
+        SelectableItem damageRocket = getDamageRocket(isNpc);
+        if (damageRocket != null) {
+            return damageRocket;
+        }
+
+        return SharedFunctions.getItemById(config.defaultRocket);
+    }
+
+    private SelectableItem getBestSabRocket(boolean isNpc) {
+        if (!this.ammoConditions.ableToUseSAB())
+            return null;
+        if (ableToUse(RocketLauncher.CBR, isNpc)) {
+            return RocketLauncher.CBR;
+        }
+        if (ableToUse(RocketLauncher.SAR_02, isNpc)) {
+            return RocketLauncher.SAR_02;
+        }
+        if (ableToUse(RocketLauncher.SAR_01, isNpc)) {
+            return RocketLauncher.SAR_01;
+        }
+        return null;
+    }
+
+    private SelectableItem getDamageRocket(boolean isNpc) {
         Lockable target = heroapi.getLocalTarget();
         if (target != null && target.isValid()) {
             if (target.getHealth().getHp() > URB_100_DAMAGE_X2
                     && ableToUse(RocketLauncher.UBR_100, isNpc)) {
                 return RocketLauncher.UBR_100;
             }
-
             if (ableToUse(RocketLauncher.HSTRM_01, isNpc)) {
                 return RocketLauncher.HSTRM_01;
             }
-
             if (ableToUse(RocketLauncher.BDR1212, isNpc)) {
                 return RocketLauncher.BDR1212;
             }
-
             if (ableToUse(RocketLauncher.ECO_10, isNpc)) {
                 return RocketLauncher.ECO_10;
             }
         }
-
-        return SharedFunctions.getItemById(config.defaultRocket);
+        return null;
     }
 
     private boolean abletToUseInfectionAmmo(boolean isNpc) {

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
@@ -101,6 +101,10 @@ public class AutoBestRocketLauncherDummy
     }
 
     private boolean changeRocketLauncher(SelectableItem rocket) {
+        if (rocket == null) {
+            return false;
+        }
+
         return items.useItem(rocket, 0, ItemFlag.USABLE, ItemFlag.READY, ItemFlag.NOT_SELECTED)
                 .isSuccessful();
     }

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
@@ -110,7 +110,7 @@ public class AutoBestRocketLauncherDummy
     }
 
     private SelectableItem getBestRocketLauncher(boolean isNpc) {
-        if (abletToUseInfectionAmmo(isNpc)) {
+        if (ableToUseInfectionAmmo(isNpc)) {
             return RocketLauncher.PIR_100;
         }
 
@@ -162,7 +162,7 @@ public class AutoBestRocketLauncherDummy
         return null;
     }
 
-    private boolean abletToUseInfectionAmmo(boolean isNpc) {
+    private boolean ableToUseInfectionAmmo(boolean isNpc) {
         if (!ableToUse(RocketLauncher.PIR_100, isNpc)) {
             return false;
         }

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
@@ -26,8 +26,7 @@ import eu.darkbot.api.managers.HeroItemsAPI;
 import eu.darkbot.api.utils.Inject;
 import com.deeme.shared.AmmoConditions;
 
-@Feature(name = "Auto Best Rocket Launcher [PLUS]",
-        description = "Auto use the best Rocket Launcher")
+@Feature(name = "Auto Best Rocket Launcher", description = "Auto use the best Rocket Launcher")
 public class AutoBestRocketLauncherDummy
         implements Behavior, Configurable<BestRocketLauncherConfig>, NpcExtraProvider {
     private final HeroAPI heroapi;

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
@@ -37,6 +37,7 @@ public class AutoBestRocketLauncherDummy
     private AmmoConditions ammoConditions;
 
     private static final int URB_100_DAMAGE_X2 = 144000;
+    private static final int MIN_ROCKET_AMMO = 5;
 
     public AutoBestRocketLauncherDummy(PluginAPI api) {
         this(api, api.requireAPI(AuthAPI.class), api.requireAPI(HeroItemsAPI.class));
@@ -155,21 +156,16 @@ public class AutoBestRocketLauncherDummy
     }
 
     private boolean ableToUse(SelectableItem rocket, boolean isNpc) {
-        if (isNpc) {
-            return ableToUse(rocket, config.rocketsToUseNPCs);
-        }
+        Set<RocketLauncher> ammoToUse =
+                isNpc ? config.rocketsToUseNPCs : config.rocketsToUsePlayers;
 
-        return ableToUse(rocket, config.rocketsToUsePlayers);
-    }
-
-    private boolean ableToUse(SelectableItem rocket, Set<RocketLauncher> ammoToUse) {
         if (ammoToUse.stream()
                 .noneMatch(s -> s.getId() != null && s.getId().equals(rocket.getId()))) {
             return false;
         }
 
         Optional<Item> item = items.getItem(rocket, ItemFlag.USABLE, ItemFlag.POSITIVE_QUANTITY);
-        return item.isPresent() && item.get().getQuantity() > 5;
+        return item.isPresent() && item.get().getQuantity() > MIN_ROCKET_AMMO;
     }
 
     private boolean hasTag(Enum<?> tag) {

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/AutoBestRocketLauncherDummy.java
@@ -1,33 +1,180 @@
 package com.deeme.behaviours.bestrocketlauncher;
 
 import java.util.Arrays;
-
+import java.util.Optional;
+import java.util.Set;
+import com.deeme.types.SharedFunctions;
 import com.deeme.types.VerifierChecker;
 import com.deeme.types.backpage.Utils;
-import com.deemeplus.behaviours.bestrocketlauncher.AutoBestRocketLauncher;
-
+import com.github.manolo8.darkbot.config.NpcExtraFlag;
+import com.github.manolo8.darkbot.core.itf.NpcExtraProvider;
 import eu.darkbot.api.PluginAPI;
+import eu.darkbot.api.config.ConfigSetting;
+import eu.darkbot.api.extensions.Behavior;
+import eu.darkbot.api.extensions.Configurable;
 import eu.darkbot.api.extensions.Feature;
+import eu.darkbot.api.game.entities.Npc;
+import eu.darkbot.api.game.items.Item;
+import eu.darkbot.api.game.items.ItemFlag;
+import eu.darkbot.api.game.items.SelectableItem;
+import eu.darkbot.api.game.items.SelectableItem.RocketLauncher;
+import eu.darkbot.api.game.other.Lockable;
 import eu.darkbot.api.managers.AuthAPI;
 import eu.darkbot.api.managers.ExtensionsAPI;
+import eu.darkbot.api.managers.HeroAPI;
+import eu.darkbot.api.managers.HeroItemsAPI;
 import eu.darkbot.api.utils.Inject;
+import com.deeme.shared.AmmoConditions;
 
-@Feature(name = "Auto Best Rocket Launcher [PLUS]", description = "Auto use the best Rocket Launcher")
-public class AutoBestRocketLauncherDummy extends AutoBestRocketLauncher {
+@Feature(name = "Auto Best Rocket Launcher [PLUS]",
+        description = "Auto use the best Rocket Launcher")
+public class AutoBestRocketLauncherDummy
+        implements Behavior, Configurable<BestRocketLauncherConfig>, NpcExtraProvider {
+    private final HeroAPI heroapi;
+    private final HeroItemsAPI items;
+    private BestRocketLauncherConfig config;
+
+    private AmmoConditions ammoConditions;
+
+    private static final int URB_100_DAMAGE_X2 = 144000;
+
     public AutoBestRocketLauncherDummy(PluginAPI api) {
-        this(api, api.requireAPI(AuthAPI.class));
+        this(api, api.requireAPI(AuthAPI.class), api.requireAPI(HeroItemsAPI.class));
     }
 
     @Inject
-    public AutoBestRocketLauncherDummy(PluginAPI api, AuthAPI auth) {
-        super(api);
-
+    public AutoBestRocketLauncherDummy(PluginAPI api, AuthAPI auth, HeroItemsAPI items) {
         if (!Arrays.equals(VerifierChecker.class.getSigners(), getClass().getSigners())) {
             throw new SecurityException();
         }
 
         VerifierChecker.requireAuthenticity(auth);
         ExtensionsAPI extensionsAPI = api.requireAPI(ExtensionsAPI.class);
-        Utils.discordDonorCheck(extensionsAPI.getFeatureInfo(this.getClass()), auth.getAuthId());
+        Utils.discordCheck(extensionsAPI.getFeatureInfo(this.getClass()), auth.getAuthId());
+
+        this.items = items;
+        this.heroapi = api.requireAPI(HeroAPI.class);
+        this.ammoConditions = new AmmoConditions(api, heroapi);
+    }
+
+    @Override
+    public NpcExtraFlag[] values() {
+        return ExtraNpcFlagsEnum.values();
+    }
+
+
+    @Override
+    public void setConfig(ConfigSetting<BestRocketLauncherConfig> arg0) {
+        this.config = arg0.getValue();
+    }
+
+
+    @Override
+    public void onTickBehavior() {
+        tick();
+    }
+
+    @Override
+    public void onStoppedBehavior() {
+        if (hasOption(BehaviourOptionsEnum.TICK_STOPPED)) {
+            tick();
+        }
+    }
+
+    private void tick() {
+        if (!config.enable) {
+            return;
+        }
+        Lockable target = heroapi.getLocalTarget();
+        if (target != null && target.isValid() && heroapi.isAttacking()) {
+            boolean isNpc = target instanceof Npc;
+            if (hasTag(ExtraNpcFlagsEnum.BEST_AMMO)
+                    || (!isNpc && hasOption(BehaviourOptionsEnum.VS_PLAYERS))
+                    || (isNpc && hasOption(BehaviourOptionsEnum.ALWAYS_FOR_NPC))
+                    || heroapi.getHealth().hpPercent() <= config.alwaysUseBellowHp) {
+                changeRocketLauncher(getBestRocketLauncher(isNpc));
+                return;
+            }
+        }
+        changeRocketLauncher(SharedFunctions.getItemById(config.defaultRocket));
+    }
+
+    private boolean changeRocketLauncher(SelectableItem rocket) {
+        return items.useItem(rocket, 0, ItemFlag.USABLE, ItemFlag.READY, ItemFlag.NOT_SELECTED)
+                .isSuccessful();
+    }
+
+    private SelectableItem getBestRocketLauncher(boolean isNpc) {
+        if (abletToUseInfectionAmmo(isNpc)) {
+            return RocketLauncher.PIR_100;
+        }
+
+        if (this.ammoConditions.ableToUseSAB()) {
+            if (ableToUse(RocketLauncher.CBR, isNpc)) {
+                return RocketLauncher.CBR;
+            } else if (ableToUse(RocketLauncher.SAR_02, isNpc)) {
+                return RocketLauncher.SAR_02;
+            } else if (ableToUse(RocketLauncher.SAR_01, isNpc)) {
+                return RocketLauncher.SAR_01;
+            }
+        }
+
+        Lockable target = heroapi.getLocalTarget();
+        if (target != null && target.isValid()) {
+            if (target.getHealth().getHp() > URB_100_DAMAGE_X2
+                    && ableToUse(RocketLauncher.UBR_100, isNpc)) {
+                return RocketLauncher.UBR_100;
+            }
+
+            if (ableToUse(RocketLauncher.HSTRM_01, isNpc)) {
+                return RocketLauncher.HSTRM_01;
+            }
+
+            if (ableToUse(RocketLauncher.BDR1212, isNpc)) {
+                return RocketLauncher.BDR1212;
+            }
+
+            if (ableToUse(RocketLauncher.ECO_10, isNpc)) {
+                return RocketLauncher.ECO_10;
+            }
+        }
+
+        return SharedFunctions.getItemById(config.defaultRocket);
+    }
+
+    private boolean abletToUseInfectionAmmo(boolean isNpc) {
+        if (!ableToUse(RocketLauncher.PIR_100, isNpc)) {
+            return false;
+        }
+
+        return this.ammoConditions.ableToUseInfectionAmmo();
+    }
+
+    private boolean hasOption(BehaviourOptionsEnum option) {
+        return config.options.stream().anyMatch(s -> s.name().equals(option.name()));
+    }
+
+    private boolean ableToUse(SelectableItem rocket, boolean isNpc) {
+        if (isNpc) {
+            return ableToUse(rocket, config.rocketsToUseNPCs);
+        }
+
+        return ableToUse(rocket, config.rocketsToUsePlayers);
+    }
+
+    private boolean ableToUse(SelectableItem rocket, Set<RocketLauncher> ammoToUse) {
+        if (ammoToUse.stream()
+                .noneMatch(s -> s.getId() != null && s.getId().equals(rocket.getId()))) {
+            return false;
+        }
+
+        Optional<Item> item = items.getItem(rocket, ItemFlag.USABLE, ItemFlag.POSITIVE_QUANTITY);
+        return item.isPresent() && item.get().getQuantity() > 5;
+    }
+
+    private boolean hasTag(Enum<?> tag) {
+        Lockable target = heroapi.getLocalTarget();
+        return (target != null && target.isValid() && target instanceof Npc
+                && ((Npc) target).getInfo().hasExtraFlag(tag));
     }
 }

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/BehaviourOptionsEnum.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/BehaviourOptionsEnum.java
@@ -1,0 +1,8 @@
+package com.deeme.behaviours.bestrocketlauncher;
+
+import eu.darkbot.api.config.annotations.Configuration;
+
+@Configuration("general.options")
+public enum BehaviourOptionsEnum {
+    VS_PLAYERS, TICK_STOPPED, ALWAYS_FOR_NPC
+}

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/BestRocketLauncherConfig.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/BestRocketLauncherConfig.java
@@ -30,7 +30,7 @@ public class BestRocketLauncherConfig {
     @Dropdown(multi = true)
     public Set<BehaviourOptionsEnum> options = EnumSet.of(BehaviourOptionsEnum.VS_PLAYERS);
 
-    @Option("general.always_use_bellow_hp")
+    @Option("general.always_use_below_hp")
     @Percentage
     public double alwaysUseBellowHp = 0;
 }

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/BestRocketLauncherConfig.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/BestRocketLauncherConfig.java
@@ -2,9 +2,7 @@ package com.deeme.behaviours.bestrocketlauncher;
 
 import java.util.EnumSet;
 import java.util.Set;
-
-import com.deemeplus.suppliers.RocketLauncherSupplier;
-
+import com.deeme.types.suppliers.RocketLauncherSupplier;
 import eu.darkbot.api.config.annotations.Configuration;
 import eu.darkbot.api.config.annotations.Dropdown;
 import eu.darkbot.api.config.annotations.Option;

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/BestRocketLauncherConfig.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/BestRocketLauncherConfig.java
@@ -1,0 +1,38 @@
+package com.deeme.behaviours.bestrocketlauncher;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import com.deemeplus.suppliers.RocketLauncherSupplier;
+
+import eu.darkbot.api.config.annotations.Configuration;
+import eu.darkbot.api.config.annotations.Dropdown;
+import eu.darkbot.api.config.annotations.Option;
+import eu.darkbot.api.config.annotations.Percentage;
+import eu.darkbot.api.game.items.SelectableItem.RocketLauncher;
+
+@Configuration("best_rocket_launcher")
+public class BestRocketLauncherConfig {
+    @Option("general.enabled")
+    public boolean enable = false;
+
+    @Option("general.default_rocket_launcher")
+    @Dropdown(options = RocketLauncherSupplier.class)
+    public String defaultRocket = "";
+
+    @Option("best_rocket_launcher.rockets_to_use_npcs")
+    @Dropdown(multi = true)
+    public Set<RocketLauncher> rocketsToUseNPCs = EnumSet.allOf(RocketLauncher.class);
+
+    @Option("best_rocket_launcher.rockets_to_use_pvp")
+    @Dropdown(multi = true)
+    public Set<RocketLauncher> rocketsToUsePlayers = EnumSet.allOf(RocketLauncher.class);
+
+    @Option("general.options")
+    @Dropdown(multi = true)
+    public Set<BehaviourOptionsEnum> options = EnumSet.of(BehaviourOptionsEnum.VS_PLAYERS);
+
+    @Option("general.always_use_bellow_hp")
+    @Percentage
+    public double alwaysUseBellowHp = 0;
+}

--- a/src/main/java/com/deeme/behaviours/bestrocketlauncher/ExtraNpcFlagsEnum.java
+++ b/src/main/java/com/deeme/behaviours/bestrocketlauncher/ExtraNpcFlagsEnum.java
@@ -1,0 +1,32 @@
+package com.deeme.behaviours.bestrocketlauncher;
+
+import com.github.manolo8.darkbot.config.NpcExtraFlag;
+
+public enum ExtraNpcFlagsEnum implements NpcExtraFlag {
+    BEST_AMMO("ABRL", "Auto Best Rocket Launcher", "Auto choose the best rocket launcher");
+
+    private final String shortName;
+    private final String name;
+    private final String description;
+
+    ExtraNpcFlagsEnum(String shortName, String name, String description) {
+        this.shortName = shortName;
+        this.name = name;
+        this.description = description;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getShortName() {
+        return shortName;
+    }
+}

--- a/src/main/java/com/deeme/behaviours/defense/AmmoConfig.java
+++ b/src/main/java/com/deeme/behaviours/defense/AmmoConfig.java
@@ -1,8 +1,7 @@
 package com.deeme.behaviours.defense;
 
 import eu.darkbot.api.config.annotations.Option;
-
-import com.deemeplus.suppliers.LaserSupplier;
+import com.deeme.types.suppliers.LaserSupplier;
 import com.github.manolo8.darkbot.config.Config.Loot.Sab;
 
 import eu.darkbot.api.config.annotations.Configuration;

--- a/src/main/java/com/deeme/modules/astral/AstralConfig.java
+++ b/src/main/java/com/deeme/modules/astral/AstralConfig.java
@@ -4,10 +4,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.deeme.behaviours.bestrocket.RocketSupplier;
+import com.deeme.types.suppliers.LaserSupplier;
 import com.deemeplus.modules.astral.AstralPlusConfig;
 import com.deemeplus.modules.astral.CustomItemPriority;
 import com.deemeplus.modules.astral.PortalInfo;
-import com.deemeplus.suppliers.LaserSupplier;
 
 import eu.darkbot.api.config.annotations.Configuration;
 import eu.darkbot.api.config.annotations.Dropdown;

--- a/src/main/java/com/deeme/types/suppliers/LaserSupplier.java
+++ b/src/main/java/com/deeme/types/suppliers/LaserSupplier.java
@@ -1,0 +1,34 @@
+package com.deeme.types.suppliers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.darkbot.api.config.annotations.Dropdown;
+import eu.darkbot.api.game.items.SelectableItem;
+import eu.darkbot.api.game.items.SelectableItem.Laser;
+
+public class LaserSupplier implements Dropdown.Options<String> {
+    private static ArrayList<String> allItemsIds = new ArrayList<>();
+
+    @Override
+    public List<String> options() {
+        if (allItemsIds.isEmpty()) {
+            Laser[] selectableItemList = SelectableItem.Laser.values();
+            for (Laser laser : selectableItemList) {
+                allItemsIds.add(laser.getId());
+            }
+        }
+        return allItemsIds;
+    }
+
+    @Override
+    public String getText(String id) {
+        Laser[] selectableItemList = SelectableItem.Laser.values();
+        for (Laser laser : selectableItemList) {
+            if (laser.getId().equals(id)) {
+                return laser.name();
+            }
+        }
+        return id;
+    }
+}

--- a/src/main/java/com/deeme/types/suppliers/RocketLauncherSupplier.java
+++ b/src/main/java/com/deeme/types/suppliers/RocketLauncherSupplier.java
@@ -1,0 +1,34 @@
+package com.deeme.types.suppliers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.darkbot.api.config.annotations.Dropdown;
+import eu.darkbot.api.game.items.SelectableItem;
+import eu.darkbot.api.game.items.SelectableItem.RocketLauncher;
+
+public class RocketLauncherSupplier implements Dropdown.Options<String> {
+    private static ArrayList<String> allItemsIds = new ArrayList<>();
+
+    @Override
+    public List<String> options() {
+        if (allItemsIds.isEmpty()) {
+            RocketLauncher[] selectableItemList = SelectableItem.RocketLauncher.values();
+            for (RocketLauncher rocket : selectableItemList) {
+                allItemsIds.add(rocket.getId());
+            }
+        }
+        return allItemsIds;
+    }
+
+    @Override
+    public String getText(String id) {
+        RocketLauncher[] selectableItemList = SelectableItem.RocketLauncher.values();
+        for (RocketLauncher rocket : selectableItemList) {
+            if (rocket.getId().equals(id)) {
+                return rocket.name();
+            }
+        }
+        return id;
+    }
+}

--- a/src/main/resources/com/deeme/lang/strings_bg.properties
+++ b/src/main/resources/com/deeme/lang/strings_bg.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Tick with bot stopped
 general.tick_stopped.desc=Used for testing, do not activate
 general.default_laser=Default Laser
 general.default_rocket_launcher=Default Rocket Launcher
-general.always_use_bellow_hp=Always use if the HP is below
-general.always_use_bellow_hp.desc=It will always use it if the HP is below the configured percentage. 0 \= Disabled
+general.always_use_below_hp=Always use if the HP is below
+general.always_use_below_hp.desc=It will always use it if the HP is below the configured percentage. 0 \= Disabled
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_cs.properties
+++ b/src/main/resources/com/deeme/lang/strings_cs.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Zastaven
 general.tick_stopped.desc=Používá se k testování, neaktivuje se
 general.default_laser=Výchozí laser
 general.default_rocket_launcher=Výchozí raketometr
-general.always_use_bellow_hp=Vždy používejte pokud je HP níže
-general.always_use_bellow_hp.desc=Vždy je bude používat, pokud je HP pod nastaveným procentem. 0 \= Zakázáno
+general.always_use_below_hp=Vždy používejte pokud je HP níže
+general.always_use_below_hp.desc=Vždy je bude používat, pokud je HP pod nastaveným procentem. 0 \= Zakázáno
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_de.properties
+++ b/src/main/resources/com/deeme/lang/strings_de.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Ticken mit Bot gestoppt
 general.tick_stopped.desc=Zum Testen nicht aktivieren
 general.default_laser=Standard-Laser
 general.default_rocket_launcher=Standard-Raketenwerfer
-general.always_use_bellow_hp=Immer verwenden, wenn die HP unten ist
-general.always_use_bellow_hp.desc=Es wird immer verwendet, wenn die HP unter dem konfigurierten Prozentsatz liegt. 0 \= Deaktiviert
+general.always_use_below_hp=Immer verwenden, wenn die HP unten ist
+general.always_use_below_hp.desc=Es wird immer verwendet, wenn die HP unter dem konfigurierten Prozentsatz liegt. 0 \= Deaktiviert
 general.item_condition=Item Condition
 general.min_time_per_action=Mindestzeit zwischen Aktionen
 general.min_time_per_action.desc=Mindestzeit zwischen Aktionen (in Sekunden)

--- a/src/main/resources/com/deeme/lang/strings_el.properties
+++ b/src/main/resources/com/deeme/lang/strings_el.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Η επιλογή με bot σταμάτησε
 general.tick_stopped.desc=Χρησιμοποιείται για τη δοκιμή, μην ενεργοποιήσετε
 general.default_laser=Προεπιλεγμένο Λέιζερ
 general.default_rocket_launcher=Προεπιλεγμένο Πρόγραμμα Εκκίνησης Πύραυλου
-general.always_use_bellow_hp=Να χρησιμοποιείται πάντα εάν η HP είναι κάτω
-general.always_use_bellow_hp.desc=Θα το χρησιμοποιεί πάντα αν το HP είναι κάτω από το ρυθμισμένο ποσοστό. 0 \= Απενεργοποιημένο
+general.always_use_below_hp=Να χρησιμοποιείται πάντα εάν η HP είναι κάτω
+general.always_use_below_hp.desc=Θα το χρησιμοποιεί πάντα αν το HP είναι κάτω από το ρυθμισμένο ποσοστό. 0 \= Απενεργοποιημένο
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_en.properties
+++ b/src/main/resources/com/deeme/lang/strings_en.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Tick with bot stopped
 general.tick_stopped.desc=Used for testing, do not activate
 general.default_laser=Default Laser
 general.default_rocket_launcher=Default Rocket Launcher
-general.always_use_bellow_hp=Always use if the HP is below
-general.always_use_bellow_hp.desc=It will always use it if the HP is below the configured percentage. 0 = Disabled
+general.always_use_below_hp=Always use if the HP is below
+general.always_use_below_hp.desc=It will always use it if the HP is below the configured percentage. 0 = Disabled
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_es.properties
+++ b/src/main/resources/com/deeme/lang/strings_es.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Activar incluso con el bot pausado
 general.tick_stopped.desc=Utilizado para pruebas, no activar
 general.default_laser=Láser por defecto
 general.default_rocket_launcher=Lanzamisiles por defecto
-general.always_use_bellow_hp=Usar si los HP están por debajo
-general.always_use_bellow_hp.desc=Usar si los HP están por debajo del porcentaje configurado. 0 \= Desactivado
+general.always_use_below_hp=Usar si los HP están por debajo
+general.always_use_below_hp.desc=Usar si los HP están por debajo del porcentaje configurado. 0 \= Desactivado
 general.item_condition=Condición de Item
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_fr.properties
+++ b/src/main/resources/com/deeme/lang/strings_fr.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Cocher avec le bot arrêté
 general.tick_stopped.desc=Utilisé pour les tests, ne pas activer
 general.default_laser=Laser par défaut
 general.default_rocket_launcher=Lance-roquettes par défaut
-general.always_use_bellow_hp=Toujours utiliser si les PV sont inférieurs
-general.always_use_bellow_hp.desc=Il l'utilisera toujours si le PV est en dessous du pourcentage configuré. 0 \= Désactivé
+general.always_use_below_hp=Toujours utiliser si les PV sont inférieurs
+general.always_use_below_hp.desc=Il l'utilisera toujours si le PV est en dessous du pourcentage configuré. 0 \= Désactivé
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_hu.properties
+++ b/src/main/resources/com/deeme/lang/strings_hu.properties
@@ -34,8 +34,8 @@ general.tick_stopped=A bot megállítása
 general.tick_stopped.desc=Tesztelésre használt, ne aktiválja
 general.default_laser=Default Laser
 general.default_rocket_launcher=Default Rocket Launcher
-general.always_use_bellow_hp=Always use if the HP is below
-general.always_use_bellow_hp.desc=It will always use it if the HP is below the configured percentage. 0 \= Disabled
+general.always_use_below_hp=Always use if the HP is below
+general.always_use_below_hp.desc=It will always use it if the HP is below the configured percentage. 0 \= Disabled
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_it.properties
+++ b/src/main/resources/com/deeme/lang/strings_it.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Tick con bot fermato
 general.tick_stopped.desc=Usato per il test, non attivare
 general.default_laser=Laser Predefinito
 general.default_rocket_launcher=Lancia Razzi Predefinita
-general.always_use_bellow_hp=Usare sempre se l’HP è sotto
-general.always_use_bellow_hp.desc=Lo userà sempre se l'HP è sotto la percentuale configurata. 0 \= Disabilitato
+general.always_use_below_hp=Usare sempre se l’HP è sotto
+general.always_use_below_hp.desc=Lo userà sempre se l'HP è sotto la percentuale configurata. 0 \= Disabilitato
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_lt.properties
+++ b/src/main/resources/com/deeme/lang/strings_lt.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Varnelė su sustabdytu bot
 general.tick_stopped.desc=Naudotas testavimui, neaktyvinti
 general.default_laser=Default Laser
 general.default_rocket_launcher=Default Rocket Launcher
-general.always_use_bellow_hp=Always use if the HP is below
-general.always_use_bellow_hp.desc=It will always use it if the HP is below the configured percentage. 0 \= Disabled
+general.always_use_below_hp=Always use if the HP is below
+general.always_use_below_hp.desc=It will always use it if the HP is below the configured percentage. 0 \= Disabled
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_pl.properties
+++ b/src/main/resources/com/deeme/lang/strings_pl.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Używaj, nawet gdy bot jest zatrzymany
 general.tick_stopped.desc=Używane do testowania, nie aktywuj
 general.default_laser=Domyślny Laser
 general.default_rocket_launcher=Domyślna wyrzutnia rakiet
-general.always_use_bellow_hp=Zawsze używaj, jeśli HP jest poniżej
-general.always_use_bellow_hp.desc=Zawsze będzie używać, jeśli HP jest poniżej skonfigurowanego procentu. 0 \= Wyłączone
+general.always_use_below_hp=Zawsze używaj, jeśli HP jest poniżej
+general.always_use_below_hp.desc=Zawsze będzie używać, jeśli HP jest poniżej skonfigurowanego procentu. 0 \= Wyłączone
 general.item_condition=Warunek użycia przedmiotu
 general.min_time_per_action=Minimalny czas pomiędzy akcjami
 general.min_time_per_action.desc=Minimalny czas pomiędzy akcjami (w sekundach)

--- a/src/main/resources/com/deeme/lang/strings_pt.properties
+++ b/src/main/resources/com/deeme/lang/strings_pt.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Marcar com bot parado
 general.tick_stopped.desc=Usado para testes, não ativar
 general.default_laser=Laser Padrão
 general.default_rocket_launcher=Mísseis padrão
-general.always_use_bellow_hp=Sempre use se o PV estiver abaixo
-general.always_use_bellow_hp.desc=Ele sempre o usará se o PV estiver abaixo da porcentagem configurada. 0 \= Desativado
+general.always_use_below_hp=Sempre use se o PV estiver abaixo
+general.always_use_below_hp.desc=Ele sempre o usará se o PV estiver abaixo da porcentagem configurada. 0 \= Desativado
 general.item_condition=Condição de Item
 general.min_time_per_action=Tempo mínimo entre ações
 general.min_time_per_action.desc=Tempo mínimo entre ações (em segundos)

--- a/src/main/resources/com/deeme/lang/strings_ro.properties
+++ b/src/main/resources/com/deeme/lang/strings_ro.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Bifează cu bot oprit
 general.tick_stopped.desc=Folosit pentru testare, nu activați
 general.default_laser=Laser implicit
 general.default_rocket_launcher=Lansator de rachete implicit
-general.always_use_bellow_hp=Utilizaţi întotdeauna dacă HP este mai jos
-general.always_use_bellow_hp.desc=Îl va folosi întotdeauna dacă HP este sub procentul configurat. 0 \= Dezactivat
+general.always_use_below_hp=Utilizaţi întotdeauna dacă HP este mai jos
+general.always_use_below_hp.desc=Îl va folosi întotdeauna dacă HP este sub procentul configurat. 0 \= Dezactivat
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_ru.properties
+++ b/src/main/resources/com/deeme/lang/strings_ru.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Работать, когда бот на паузе
 general.tick_stopped.desc=Используется для тестирования, не активировать
 general.default_laser=Лазер по умолчанию
 general.default_rocket_launcher=Ракетная ракета по умолчанию
-general.always_use_bellow_hp=Всегда используйте если HP ниже
-general.always_use_bellow_hp.desc=Бот всегда будет использовать это, если HP ниже заданного процента. 0 \= Отключено
+general.always_use_below_hp=Всегда используйте если HP ниже
+general.always_use_below_hp.desc=Бот всегда будет использовать это, если HP ниже заданного процента. 0 \= Отключено
 general.item_condition=Условие товара
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_sv.properties
+++ b/src/main/resources/com/deeme/lang/strings_sv.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Sparka med bot stoppad
 general.tick_stopped.desc=Används för testning, aktivera inte
 general.default_laser=Standard Laser
 general.default_rocket_launcher=Standard Raketgevär
-general.always_use_bellow_hp=Använd alltid om HP är under
-general.always_use_bellow_hp.desc=Det kommer alltid att använda det om HP är under den konfigurerade procentsatsen. 0 \= Inaktiverad
+general.always_use_below_hp=Använd alltid om HP är under
+general.always_use_below_hp.desc=Det kommer alltid att använda det om HP är under den konfigurerade procentsatsen. 0 \= Inaktiverad
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/com/deeme/lang/strings_tr.properties
+++ b/src/main/resources/com/deeme/lang/strings_tr.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Bot ile işaret durduruldu
 general.tick_stopped.desc=Test için kullanıyor, aktif etmeyin
 general.default_laser=Varsayılan Lazer
 general.default_rocket_launcher=Varsayılan Roketatar
-general.always_use_bellow_hp=Can bu miktarın altına düştüğünde her zaman kullan
-general.always_use_bellow_hp.desc=Can bu miktarın altına düştüğünde her zaman kullanır. 0 \= Devredışı
+general.always_use_below_hp=Can bu miktarın altına düştüğünde her zaman kullan
+general.always_use_below_hp.desc=Can bu miktarın altına düştüğünde her zaman kullanır. 0 \= Devredışı
 general.item_condition=Öğe Durumu
 general.min_time_per_action=Eylemler arasında minimum süre
 general.min_time_per_action.desc=Eylemler arasında minimum süre (Saniye cinsinden)

--- a/src/main/resources/com/deeme/lang/strings_uk.properties
+++ b/src/main/resources/com/deeme/lang/strings_uk.properties
@@ -34,8 +34,8 @@ general.tick_stopped=Лицько з ботом зупинено
 general.tick_stopped.desc=Використовується для тестування, не активуйте
 general.default_laser=Усталений лазер
 general.default_rocket_launcher=Ракетниця за замовчуванням
-general.always_use_bellow_hp=Завжди використовуйте, якщо нижче HP
-general.always_use_bellow_hp.desc=Він завжди буде використовувати це, якщо Здоров'я нижче показаних відсотків. 0 \= Вимкнено
+general.always_use_below_hp=Завжди використовуйте, якщо нижче HP
+general.always_use_below_hp.desc=Він завжди буде використовувати це, якщо Здоров'я нижче показаних відсотків. 0 \= Вимкнено
 general.item_condition=Item Condition
 general.min_time_per_action=Minimum time between actions
 general.min_time_per_action.desc=Minimum time between actions (In seconds)

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "DmPlugin",
   "author": "Dm94Dani",
-  "version": "2.6.0 beta 3",
+  "version": "2.6.0 beta 4",
   "minVersion": "1.131",
   "supportedVersion": "1.131.5",
   "basePackage": "com.deeme",


### PR DESCRIPTION
## Summary by Sourcery

Implement a Behavior-based AutoBestRocketLauncher plugin that dynamically switches to the optimal rocket launcher in combat based on target type, ammo availability, and health thresholds.

New Features:
- Implement Behavior-based AutoBestRocketLauncher to automatically select and switch to the optimal rocket launcher during combat
- Add BestRocketLauncherConfig with settings for default rocket, rockets-per-target (NPC/PvP), behavior options, and health-trigger threshold
- Introduce NPC extra flag support to force best-rocket selection on marked targets

Enhancements:
- Refactor from legacy dummy class to use HeroAPI, HeroItemsAPI, and AmmoConditions for ammo-driven logic
- Add BehaviourOptionsEnum and ExtraNpcFlagsEnum enums for configurable behavior toggles and NPC tagging
- Leverage SharedFunctions for default rocket retrieval and enhance item readiness checks before switching