### PR TITLE
feat(bootykey): add booty key collector manager to auto-enable collection

### DIFF
--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorConfig.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorConfig.java
@@ -4,11 +4,10 @@ import eu.darkbot.api.config.annotations.Configuration;
 import eu.darkbot.api.config.annotations.Dropdown;
 import eu.darkbot.api.config.annotations.Number;
 import eu.darkbot.api.config.annotations.Option;
-import eu.darkbot.api.game.stats.Stats;
 
 import java.util.HashSet;
 import java.util.Set;
-import com.deeme.behaviours.profilechanger.BootyKeySupplier;
+import com.deeme.types.suppliers.BootyKeySupplier;
 
 @Configuration("booty_key_collector_manager")
 public class BootyKeyCollectorConfig {

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorConfig.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorConfig.java
@@ -1,0 +1,23 @@
+package com.deeme.behaviours.bootykeymanager;
+
+import eu.darkbot.api.config.annotations.Configuration;
+import eu.darkbot.api.config.annotations.Dropdown;
+import eu.darkbot.api.config.annotations.Number;
+import eu.darkbot.api.config.annotations.Option;
+import eu.darkbot.api.game.stats.Stats;
+
+import java.util.EnumSet;
+import java.util.Set;
+import com.deeme.behaviours.profilechanger.BootyKeySupplier;
+
+@Configuration("booty_key_collector_manager")
+public class BootyKeyCollectorConfig {
+
+    @Option("booty_key_collector_manager.booty_keys_to_monitor")
+    @Dropdown(multi = true, options = BootyKeySupplier.class)
+    public Set<Stats.BootyKey> bootyKeysToMonitor = EnumSet.noneOf(Stats.BootyKey.class);
+
+    @Option("booty_key_collector_manager.check_interval")
+    @Number(min = 0, max = 2000, step = 1)
+    public int checkInterval = 30; // seconds
+}

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorConfig.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorConfig.java
@@ -18,6 +18,6 @@ public class BootyKeyCollectorConfig {
     public Set<Stats.BootyKey> bootyKeysToMonitor = EnumSet.noneOf(Stats.BootyKey.class);
 
     @Option("booty_key_collector_manager.check_interval")
-    @Number(min = 0, max = 2000, step = 1)
-    public int checkInterval = 30; // seconds
+    @Number(min = 1, max = 2000, step = 1)
+    public int checkInterval = 30;
 }

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorConfig.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorConfig.java
@@ -6,7 +6,7 @@ import eu.darkbot.api.config.annotations.Number;
 import eu.darkbot.api.config.annotations.Option;
 import eu.darkbot.api.game.stats.Stats;
 
-import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Set;
 import com.deeme.behaviours.profilechanger.BootyKeySupplier;
 
@@ -15,7 +15,7 @@ public class BootyKeyCollectorConfig {
 
     @Option("booty_key_collector_manager.booty_keys_to_monitor")
     @Dropdown(multi = true, options = BootyKeySupplier.class)
-    public Set<Stats.BootyKey> bootyKeysToMonitor = EnumSet.noneOf(Stats.BootyKey.class);
+    public Set<String> bootyKeysToMonitor = new HashSet<>();
 
     @Option("booty_key_collector_manager.check_interval")
     @Number(min = 1, max = 2000, step = 1)

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
@@ -10,7 +10,10 @@ import eu.darkbot.api.extensions.Configurable;
 import eu.darkbot.api.extensions.Feature;
 import eu.darkbot.api.extensions.FeatureInfo;
 import eu.darkbot.api.game.stats.Stats;
-import eu.darkbot.api.managers.*;
+import eu.darkbot.api.managers.AuthAPI;
+import eu.darkbot.api.managers.ConfigAPI;
+import eu.darkbot.api.managers.ExtensionsAPI;
+import eu.darkbot.api.managers.StatsAPI;
 import eu.darkbot.api.utils.Inject;
 import eu.darkbot.api.config.types.BoxInfo;
 
@@ -93,7 +96,6 @@ public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKey
         }
       } catch (IllegalArgumentException e) {
         // Skip invalid booty key names
-        continue;
       }
     }
   }
@@ -101,35 +103,32 @@ public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKey
   private Optional<String> getResourceNameForBootyKey(Stats.BootyKey bootyKey) {
     switch (bootyKey) {
       case GREEN:
-        return Optional.of("PIRATE_BOOTY");
+        return Optional.of("PIRATE_BOOTY_GOLD");
       case BLUE:
-        return Optional.of("BLUE_BOOTY");
+        return Optional.of("PIRATE_BOOTY_BLUE");
       case RED:
-        return Optional.of("RED_BOOTY");
+        return Optional.of("PIRATE_BOOTY_RED");
       case SILVER:
-        return Optional.of("SILVER_BOOTY");
+        return Optional.of("PIRATE_BOOTY_SILVER");
       case APOCALYPSE:
-        return Optional.of("APOCALYPSE_BOOTY");
+        return Optional.of("MASQUE_BOOTY_BOX");
       case PROMETHEUS:
-        return Optional.of("PROMETHEUS_BOOTY");
+        return Optional.of("PROMETHEUS_BOOTY_BOX");
       case OBSIDIAN_MICROCHIP:
-        return Optional.of("OBSIDIAN_BOOTY");
-      case BLACK_LIGHT_CODE:
-        return Optional.of("BLACK_LIGHT_BOOTY");
-      case BLACK_LIGHT_DECODER:
-        return Optional.of("BLACK_LIGHT_DECODER_BOOTY");
+        return Optional.of("BLACK_BOOTY_BOX");
       case PROSPEROUS_FRAGMENT:
-        return Optional.of("PROSPEROUS_BOOTY");
+        return Optional.of("PROSPEROUS_BOOTY_BOX");
       case ASTRAL:
-        return Optional.of("ASTRAL_BOOTY");
+        return Optional.of("ASTRAL_BOOTY_BOX");
       case ASTRAL_SUPREME:
-        return Optional.of("ASTRAL_SUPREME_BOOTY");
+        return Optional.of("ASTRAL_PRIME_BOOTY_BOX");
       case EMPYRIAN:
-        return Optional.of("EMPYRIAN_BOOTY");
-      case LUCENT:
-        return Optional.of("LUCENT_BOOTY");
+        return Optional.of("EMPYRIAN_BOOTY_BOX");
       case PERSEUS:
-        return Optional.of("PERSEUS_BOOTY");
+        return Optional.of("PERSEUS_BLESSING_BOOTY_BOX");
+      case LUCENT:
+      case BLACK_LIGHT_CODE:
+      case BLACK_LIGHT_DECODER:
       default:
         return Optional.empty();
     }

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
@@ -21,8 +21,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
-@Feature(name = "Booty Collector Manager",
-    description = "Automatically enables or disables resource collection based on Key availability")
+@Feature(name = "Booty Collector Manager", description = "Automatically enables or disables resource collection based on Key availability")
 public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKeyCollectorConfig> {
   private final StatsAPI stats;
   private final ConfigAPI configApi;
@@ -72,7 +71,7 @@ public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKey
     for (String bootyKeyName : config.bootyKeysToMonitor) {
       try {
         Stats.BootyKey bootyKey = Stats.BootyKey.valueOf(bootyKeyName);
-        Optional<String> resourceName = getResourceNameForBootyKey(bootyKey);
+        Optional<String> resourceName = BootyKeyResourceMapper.getResourceNameForBootyKey(bootyKey);
 
         if (resourceName.isPresent()) {
           BoxInfo boxInfo = allBoxes.get(resourceName.get());
@@ -84,40 +83,6 @@ public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKey
       } catch (IllegalArgumentException e) {
         // Skip invalid booty key names
       }
-    }
-  }
-
-  private Optional<String> getResourceNameForBootyKey(Stats.BootyKey bootyKey) {
-    switch (bootyKey) {
-      case GREEN:
-        return Optional.of("PIRATE_BOOTY_GOLD");
-      case BLUE:
-        return Optional.of("PIRATE_BOOTY_BLUE");
-      case RED:
-        return Optional.of("PIRATE_BOOTY_RED");
-      case SILVER:
-        return Optional.of("PIRATE_BOOTY_SILVER");
-      case APOCALYPSE:
-        return Optional.of("MASQUE_BOOTY_BOX");
-      case PROMETHEUS:
-        return Optional.of("PROMETHEUS_BOOTY_BOX");
-      case OBSIDIAN_MICROCHIP:
-        return Optional.of("BLACK_BOOTY_BOX");
-      case PROSPEROUS_FRAGMENT:
-        return Optional.of("PROSPEROUS_BOOTY_BOX");
-      case ASTRAL:
-        return Optional.of("ASTRAL_BOOTY_BOX");
-      case ASTRAL_SUPREME:
-        return Optional.of("ASTRAL_PRIME_BOOTY_BOX");
-      case EMPYRIAN:
-        return Optional.of("EMPYRIAN_BOOTY_BOX");
-      case PERSEUS:
-        return Optional.of("PERSEUS_BLESSING_BOOTY_BOX");
-      case LUCENT:
-      case BLACK_LIGHT_CODE:
-      case BLACK_LIGHT_DECODER:
-      default:
-        return Optional.empty();
     }
   }
 }

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
-@Feature(name = "BootyKey Collector Manager",
-    description = "Automatically enables or disables resource collection based on BootyKey availability")
+@Feature(name = "Booty Collector Manager",
+    description = "Automatically enables or disables resource collection based on Key availability")
 public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKeyCollectorConfig> {
   private final StatsAPI stats;
   private final ConfigAPI configApi;

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
@@ -63,35 +63,22 @@ public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKey
 
     nextCheck = System.currentTimeMillis() + (config.checkInterval * 1000L);
 
-    boolean shouldCollect = shouldEnableCollection();
-    updateResourceCollection(shouldCollect);
+    updateResourceCollectionByKey();
   }
 
-  private boolean shouldEnableCollection() {
-    for (String bootyKeyName : config.bootyKeysToMonitor) {
-      try {
-        Stats.BootyKey bootyKey = Stats.BootyKey.valueOf(bootyKeyName);
-        if (stats.getStatValue(bootyKey) > 0) {
-          return true;
-        }
-      } catch (IllegalArgumentException e) {
-        // Skip invalid booty key names
-      }
-    }
-    return false;
-  }
-
-  private void updateResourceCollection(boolean enable) {
+  private void updateResourceCollectionByKey() {
     Map<String, BoxInfo> allBoxes = boxInfos.getValue();
 
     for (String bootyKeyName : config.bootyKeysToMonitor) {
       try {
         Stats.BootyKey bootyKey = Stats.BootyKey.valueOf(bootyKeyName);
         Optional<String> resourceName = getResourceNameForBootyKey(bootyKey);
+
         if (resourceName.isPresent()) {
           BoxInfo boxInfo = allBoxes.get(resourceName.get());
           if (boxInfo != null) {
-            boxInfo.setShouldCollect(enable);
+            boolean hasKeys = stats.getStatValue(bootyKey) > 0;
+            boxInfo.setShouldCollect(hasKeys);
           }
         }
       } catch (IllegalArgumentException e) {

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
@@ -1,0 +1,126 @@
+package com.deeme.behaviours.bootykeymanager;
+
+import com.deeme.types.VerifierChecker;
+import com.deeme.types.backpage.Utils;
+
+import eu.darkbot.api.PluginAPI;
+import eu.darkbot.api.config.ConfigSetting;
+import eu.darkbot.api.extensions.Behavior;
+import eu.darkbot.api.extensions.Configurable;
+import eu.darkbot.api.extensions.Feature;
+import eu.darkbot.api.extensions.FeatureInfo;
+import eu.darkbot.api.game.stats.Stats;
+import eu.darkbot.api.managers.*;
+import eu.darkbot.api.utils.Inject;
+import eu.darkbot.api.config.types.BoxInfo;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+@Feature(name = "BootyKey Collector Manager",
+    description = "Automatically enables or disables resource collection based on BootyKey availability")
+public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKeyCollectorConfig> {
+  private final StatsAPI stats;
+  private final ConfigAPI configApi;
+
+  private BootyKeyCollectorConfig config;
+  private ConfigSetting<Map<String, BoxInfo>> boxInfos;
+  private long nextCheck = 0;
+
+  @Inject
+  public BootyKeyCollectorManager(PluginAPI api, AuthAPI auth) {
+    if (!Arrays.equals(VerifierChecker.class.getSigners(), getClass().getSigners())) {
+      throw new SecurityException();
+    }
+
+    VerifierChecker.requireAuthenticity(auth);
+
+    ExtensionsAPI extensionsAPI = api.requireAPI(ExtensionsAPI.class);
+    FeatureInfo<?> feature = extensionsAPI.getFeatureInfo(this.getClass());
+    Utils.discordCheck(feature, auth.getAuthId());
+    Utils.showDonateDialog(feature, auth.getAuthId());
+
+    this.stats = api.requireAPI(StatsAPI.class);
+    this.configApi = api.requireAPI(ConfigAPI.class);
+
+    this.boxInfos = configApi.requireConfig("collect.box_infos");
+  }
+
+  @Override
+  public void setConfig(ConfigSetting<BootyKeyCollectorConfig> config) {
+    this.config = config.getValue();
+  }
+
+  @Override
+  public void onTickBehavior() {
+    if (System.currentTimeMillis() < nextCheck) {
+      return;
+    }
+
+    nextCheck = System.currentTimeMillis() + (config.checkInterval * 1000L);
+
+    boolean shouldCollect = shouldEnableCollection();
+    updateResourceCollection(shouldCollect);
+  }
+
+  private boolean shouldEnableCollection() {
+    for (Stats.BootyKey bootyKey : config.bootyKeysToMonitor) {
+      if (stats.getStatValue(bootyKey) > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void updateResourceCollection(boolean enable) {
+    Map<String, BoxInfo> allBoxes = boxInfos.getValue();
+
+    for (Stats.BootyKey bootyKey : config.bootyKeysToMonitor) {
+      Optional<String> resourceName = getResourceNameForBootyKey(bootyKey);
+      if (resourceName.isPresent()) {
+        BoxInfo boxInfo = allBoxes.get(resourceName.get());
+        if (boxInfo != null) {
+          boxInfo.setShouldCollect(enable);
+        }
+      }
+    }
+  }
+
+  private Optional<String> getResourceNameForBootyKey(Stats.BootyKey bootyKey) {
+    switch (bootyKey) {
+      case GREEN:
+        return Optional.of("PIRATE_BOOTY");
+      case BLUE:
+        return Optional.of("BLUE_BOOTY");
+      case RED:
+        return Optional.of("RED_BOOTY");
+      case SILVER:
+        return Optional.of("SILVER_BOOTY");
+      case APOCALYPSE:
+        return Optional.of("APOCALYPSE_BOOTY");
+      case PROMETHEUS:
+        return Optional.of("PROMETHEUS_BOOTY");
+      case OBSIDIAN_MICROCHIP:
+        return Optional.of("OBSIDIAN_BOOTY");
+      case BLACK_LIGHT_CODE:
+        return Optional.of("BLACK_LIGHT_BOOTY");
+      case BLACK_LIGHT_DECODER:
+        return Optional.of("BLACK_LIGHT_DECODER_BOOTY");
+      case PROSPEROUS_FRAGMENT:
+        return Optional.of("PROSPEROUS_BOOTY");
+      case ASTRAL:
+        return Optional.of("ASTRAL_BOOTY");
+      case ASTRAL_SUPREME:
+        return Optional.of("ASTRAL_SUPREME_BOOTY");
+      case EMPYRIAN:
+        return Optional.of("EMPYRIAN_BOOTY");
+      case LUCENT:
+        return Optional.of("LUCENT_BOOTY");
+      case PERSEUS:
+        return Optional.of("PERSEUS_BOOTY");
+      default:
+        return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyCollectorManager.java
@@ -65,9 +65,14 @@ public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKey
   }
 
   private boolean shouldEnableCollection() {
-    for (Stats.BootyKey bootyKey : config.bootyKeysToMonitor) {
-      if (stats.getStatValue(bootyKey) > 0) {
-        return true;
+    for (String bootyKeyName : config.bootyKeysToMonitor) {
+      try {
+        Stats.BootyKey bootyKey = Stats.BootyKey.valueOf(bootyKeyName);
+        if (stats.getStatValue(bootyKey) > 0) {
+          return true;
+        }
+      } catch (IllegalArgumentException e) {
+        // Skip invalid booty key names
       }
     }
     return false;
@@ -76,13 +81,19 @@ public class BootyKeyCollectorManager implements Behavior, Configurable<BootyKey
   private void updateResourceCollection(boolean enable) {
     Map<String, BoxInfo> allBoxes = boxInfos.getValue();
 
-    for (Stats.BootyKey bootyKey : config.bootyKeysToMonitor) {
-      Optional<String> resourceName = getResourceNameForBootyKey(bootyKey);
-      if (resourceName.isPresent()) {
-        BoxInfo boxInfo = allBoxes.get(resourceName.get());
-        if (boxInfo != null) {
-          boxInfo.setShouldCollect(enable);
+    for (String bootyKeyName : config.bootyKeysToMonitor) {
+      try {
+        Stats.BootyKey bootyKey = Stats.BootyKey.valueOf(bootyKeyName);
+        Optional<String> resourceName = getResourceNameForBootyKey(bootyKey);
+        if (resourceName.isPresent()) {
+          BoxInfo boxInfo = allBoxes.get(resourceName.get());
+          if (boxInfo != null) {
+            boxInfo.setShouldCollect(enable);
+          }
         }
+      } catch (IllegalArgumentException e) {
+        // Skip invalid booty key names
+        continue;
       }
     }
   }

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyResourceMapper.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyResourceMapper.java
@@ -25,6 +25,10 @@ public class BootyKeyResourceMapper {
                     Map.entry(Stats.BootyKey.BLACK_LIGHT_CODE, "UNSTABLE_BLACKLIGHT_CACHE"),
                     Map.entry(Stats.BootyKey.BLACK_LIGHT_DECODER, "BLACKLIGHT-CRYPT"));
 
+    private BootyKeyResourceMapper() {
+        throw new UnsupportedOperationException("This class cannot be instantiated");
+    }
+
     /**
      * Gets the resource name for a given BootyKey.
      * 

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyResourceMapper.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyResourceMapper.java
@@ -1,7 +1,6 @@
 package com.deeme.behaviours.bootykeymanager;
 
 import eu.darkbot.api.game.stats.Stats;
-
 import java.util.Map;
 import java.util.Optional;
 
@@ -9,26 +8,28 @@ import java.util.Optional;
  * Helper class that maps BootyKey types to their corresponding resource names.
  */
 public class BootyKeyResourceMapper {
-    private static final Map<Stats.BootyKey, String> BOOTY_RESOURCE_MAP = Map.ofEntries(
-            Map.entry(Stats.BootyKey.GREEN, "PIRATE_BOOTY_GOLD"),
-            Map.entry(Stats.BootyKey.BLUE, "PIRATE_BOOTY_BLUE"),
-            Map.entry(Stats.BootyKey.RED, "PIRATE_BOOTY_RED"),
-            Map.entry(Stats.BootyKey.SILVER, "PIRATE_BOOTY_SILVER"),
-            Map.entry(Stats.BootyKey.APOCALYPSE, "MASQUE_BOOTY_BOX"),
-            Map.entry(Stats.BootyKey.PROMETHEUS, "PROMETHEUS_BOOTY_BOX"),
-            Map.entry(Stats.BootyKey.OBSIDIAN_MICROCHIP, "BLACK_BOOTY_BOX"),
-            Map.entry(Stats.BootyKey.PROSPEROUS_FRAGMENT, "PROSPEROUS_BOOTY_BOX"),
-            Map.entry(Stats.BootyKey.ASTRAL, "ASTRAL_BOOTY_BOX"),
-            Map.entry(Stats.BootyKey.ASTRAL_SUPREME, "ASTRAL_PRIME_BOOTY_BOX"),
-            Map.entry(Stats.BootyKey.EMPYRIAN, "EMPYRIAN_BOOTY_BOX"),
-            Map.entry(Stats.BootyKey.PERSEUS, "PERSEUS_BLESSING_BOOTY_BOX"));
+    private static final Map<Stats.BootyKey, String> BOOTY_RESOURCE_MAP =
+            Map.ofEntries(Map.entry(Stats.BootyKey.GREEN, "PIRATE_BOOTY_GOLD"),
+                    Map.entry(Stats.BootyKey.BLUE, "PIRATE_BOOTY_BLUE"),
+                    Map.entry(Stats.BootyKey.RED, "PIRATE_BOOTY_RED"),
+                    Map.entry(Stats.BootyKey.SILVER, "PIRATE_BOOTY_SILVER"),
+                    Map.entry(Stats.BootyKey.APOCALYPSE, "MASQUE_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.PROMETHEUS, "PROMETHEUS_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.OBSIDIAN_MICROCHIP, "BLACK_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.PROSPEROUS_FRAGMENT, "PROSPEROUS_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.ASTRAL, "ASTRAL_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.ASTRAL_SUPREME, "ASTRAL_PRIME_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.EMPYRIAN, "EMPYRIAN_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.PERSEUS, "PERSEUS_BLESSING_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.LUCENT, "LUCENT_ALIEN_EGG_BOOTY_BOX"),
+                    Map.entry(Stats.BootyKey.BLACK_LIGHT_CODE, "UNSTABLE_BLACKLIGHT_CACHE"),
+                    Map.entry(Stats.BootyKey.BLACK_LIGHT_DECODER, "BLACKLIGHT-CRYPT"));
 
     /**
      * Gets the resource name for a given BootyKey.
      * 
      * @param bootyKey the BootyKey to get the resource name for
-     * @return Optional containing the resource name if mapping exists, empty
-     *         otherwise
+     * @return Optional containing the resource name if mapping exists, empty otherwise
      */
     public static Optional<String> getResourceNameForBootyKey(Stats.BootyKey bootyKey) {
         return Optional.ofNullable(BOOTY_RESOURCE_MAP.get(bootyKey));

--- a/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyResourceMapper.java
+++ b/src/main/java/com/deeme/behaviours/bootykeymanager/BootyKeyResourceMapper.java
@@ -1,0 +1,36 @@
+package com.deeme.behaviours.bootykeymanager;
+
+import eu.darkbot.api.game.stats.Stats;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Helper class that maps BootyKey types to their corresponding resource names.
+ */
+public class BootyKeyResourceMapper {
+    private static final Map<Stats.BootyKey, String> BOOTY_RESOURCE_MAP = Map.ofEntries(
+            Map.entry(Stats.BootyKey.GREEN, "PIRATE_BOOTY_GOLD"),
+            Map.entry(Stats.BootyKey.BLUE, "PIRATE_BOOTY_BLUE"),
+            Map.entry(Stats.BootyKey.RED, "PIRATE_BOOTY_RED"),
+            Map.entry(Stats.BootyKey.SILVER, "PIRATE_BOOTY_SILVER"),
+            Map.entry(Stats.BootyKey.APOCALYPSE, "MASQUE_BOOTY_BOX"),
+            Map.entry(Stats.BootyKey.PROMETHEUS, "PROMETHEUS_BOOTY_BOX"),
+            Map.entry(Stats.BootyKey.OBSIDIAN_MICROCHIP, "BLACK_BOOTY_BOX"),
+            Map.entry(Stats.BootyKey.PROSPEROUS_FRAGMENT, "PROSPEROUS_BOOTY_BOX"),
+            Map.entry(Stats.BootyKey.ASTRAL, "ASTRAL_BOOTY_BOX"),
+            Map.entry(Stats.BootyKey.ASTRAL_SUPREME, "ASTRAL_PRIME_BOOTY_BOX"),
+            Map.entry(Stats.BootyKey.EMPYRIAN, "EMPYRIAN_BOOTY_BOX"),
+            Map.entry(Stats.BootyKey.PERSEUS, "PERSEUS_BLESSING_BOOTY_BOX"));
+
+    /**
+     * Gets the resource name for a given BootyKey.
+     * 
+     * @param bootyKey the BootyKey to get the resource name for
+     * @return Optional containing the resource name if mapping exists, empty
+     *         otherwise
+     */
+    public static Optional<String> getResourceNameForBootyKey(Stats.BootyKey bootyKey) {
+        return Optional.ofNullable(BOOTY_RESOURCE_MAP.get(bootyKey));
+    }
+}

--- a/src/main/java/com/deeme/behaviours/profilechanger/KeyCondition.java
+++ b/src/main/java/com/deeme/behaviours/profilechanger/KeyCondition.java
@@ -1,5 +1,6 @@
 package com.deeme.behaviours.profilechanger;
 
+import com.deeme.types.suppliers.BootyKeySupplier;
 import eu.darkbot.api.config.annotations.Configuration;
 import eu.darkbot.api.config.annotations.Dropdown;
 import eu.darkbot.api.config.annotations.Option;

--- a/src/main/java/com/deeme/types/suppliers/BootyKeySupplier.java
+++ b/src/main/java/com/deeme/types/suppliers/BootyKeySupplier.java
@@ -1,4 +1,4 @@
-package com.deeme.behaviours.profilechanger;
+package com.deeme.types.suppliers;
 
 import eu.darkbot.api.config.annotations.Dropdown;
 import eu.darkbot.api.game.stats.Stats.BootyKey;
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class BootyKeySupplier implements Dropdown.Options<String> {
 
-    private static List<String> keyInfos = new ArrayList<String>();
+    private static List<String> keyInfos = new ArrayList<>();
 
     @Override
     public List<String> options() {

--- a/src/main/resources/com/deeme/lang/strings_en.properties
+++ b/src/main/resources/com/deeme/lang/strings_en.properties
@@ -469,3 +469,15 @@ guiModule.step.y=Y position
 guiModule.step.secondsToWait=Seconds to wait
 guiModule.stepsToFollow=Steps to follow
 guiModule.profileToChange=Profile to change
+
+booty_key_collector_manager=BootyKey Collector Manager
+booty_key_collector_manager.booty_keys_to_monitor=BootyKeys to monitor
+booty_key_collector_manager.booty_keys_to_monitor.desc=Select the BootyKeys you want to monitor to enable resource collection
+booty_key_collector_manager.show_notifications=Show notifications
+booty_key_collector_manager.show_notifications.desc=Show notifications in chat when collection is enabled or disabled
+booty_key_collector_manager.reset_on_stop=Reset on stop
+booty_key_collector_manager.reset_on_stop.desc=Reset collection state to default when bot is stopped
+booty_key_collector_manager.default_collector_state=Default collector state
+booty_key_collector_manager.default_collector_state.desc=Default collection state when reset
+booty_key_collector_manager.check_interval=Check interval
+booty_key_collector_manager.check_interval.desc=Interval in seconds to check BootyKey availability

--- a/src/main/resources/com/deeme/lang/strings_es.properties
+++ b/src/main/resources/com/deeme/lang/strings_es.properties
@@ -469,3 +469,15 @@ guiModule.step.y=Y position
 guiModule.step.secondsToWait=Seconds to wait
 guiModule.stepsToFollow=Steps to follow
 guiModule.profileToChange=Profile to change
+
+booty_key_collector_manager=Gestor de Recolección de BootyKeys
+booty_key_collector_manager.booty_keys_to_monitor=BootyKeys a monitorear
+booty_key_collector_manager.booty_keys_to_monitor.desc=Selecciona las BootyKeys que quieres que se monitoreen para activar la recolección
+booty_key_collector_manager.show_notifications=Mostrar notificaciones
+booty_key_collector_manager.show_notifications.desc=Muestra notificaciones en el chat cuando se activa o desactiva la recolección
+booty_key_collector_manager.reset_on_stop=Restablecer al parar
+booty_key_collector_manager.reset_on_stop.desc=Restablece el estado de recolección al estado por defecto cuando se para el bot
+booty_key_collector_manager.default_collector_state=Estado por defecto del recolector
+booty_key_collector_manager.default_collector_state.desc=Estado por defecto de la recolección cuando se restablece
+booty_key_collector_manager.check_interval=Intervalo de comprobación
+booty_key_collector_manager.check_interval.desc=Intervalo en segundos para comprobar la disponibilidad de BootyKeys

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "DmPlugin",
   "author": "Dm94Dani",
-  "version": "2.8.0 beta 2",
+  "version": "2.8.0 beta 3",
   "minVersion": "1.131.5",
   "supportedVersion": "1.131.6 beta 3",
   "basePackage": "com.deeme",

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -32,7 +32,8 @@
     "com.deeme.behaviours.bestrocketlauncher.AutoBestRocketLauncherDummy",
     "com.deeme.behaviours.autocloack.AutoCloack",
     "com.deeme.behaviours.antitrain.AntiTrain",
-    "com.deeme.behaviours.urgentdetector.UrgentDetector"
+    "com.deeme.behaviours.urgentdetector.UrgentDetector",
+    "com.deeme.behaviours.bootykeymanager.BootyKeyCollectorManager"
   ],
   "donation": "https://ko-fi.com/deeme",
   "discord": "https://discord.gg/GPRTRRZJPw",

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "DmPlugin",
   "author": "Dm94Dani",
-  "version": "2.8.0 beta 1",
+  "version": "2.8.0 beta 2",
   "minVersion": "1.131.5",
   "supportedVersion": "1.131.6 beta 3",
   "basePackage": "com.deeme",

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "DmPlugin",
   "author": "Dm94Dani",
-  "version": "2.7.1 beta 1",
+  "version": "2.8.0 beta 1",
   "minVersion": "1.131.5",
   "supportedVersion": "1.131.6 beta 3",
   "basePackage": "com.deeme",


### PR DESCRIPTION
## Summary by Sourcery

Add a new BootyKeyCollectorManager behavior to automatically toggle resource collection boxes based on BootyKey stats with configurable monitored keys and check interval, accompanied by supporting config, supplier, and localization entries.

New Features:
- Implement BootyKeyCollectorManager behavior to enable/disable collection based on BootyKey availability
- Provide BootyKeyCollectorConfig with multi-select key options and adjustable check interval
- Add BootyKeySupplier class for dropdown key selection

Enhancements:
- Refactor BootyKeySupplier list initialization to use type inference

Documentation:
- Add English and Spanish localization strings for BootyKey Collector Manager and its settings