### PR TITLE
Update PVPConfig.java

### DIFF
--- a/src/main/java/com/deeme/modules/pvp/PVPConfig.java
+++ b/src/main/java/com/deeme/modules/pvp/PVPConfig.java
@@ -25,7 +25,7 @@ public class PVPConfig {
     public boolean ignoreInvisible = false;
 
     @Option("auto_attack.max_range")
-    @Number(min = 0, max = 1000, step = 50)
+    @Number(min = 0, max = 3000, step = 50)
     public int rangeForEnemies = 500;
 
     @Option("defense.max_time_out")


### PR DESCRIPTION
Maximum PvP range added to 3000

## Summary by Sourcery

Enhancements:
- Raise the upper bound of the auto-attack enemy range configuration from 1000 to 3000 units.