### PR TITLE
fix(SentinelModule): improve target clearing logic during attack cool…

### DIFF
--- a/src/main/java/com/deeme/modules/SentinelModule.java
+++ b/src/main/java/com/deeme/modules/SentinelModule.java
@@ -347,7 +347,10 @@ public class SentinelModule implements Module, Configurable<SentinelConfig>, Ins
 
     private boolean isAttacking() {
         if (this.randomWaitTime > System.currentTimeMillis()) {
-            return this.oldTarget != null;
+            if (shouldKeepOldTarget()) {
+                return true;
+            }
+            clearAttackTargets();
         }
 
         if (sConfig.humanizer.addRandomTime) {
@@ -373,11 +376,32 @@ public class SentinelModule implements Module, Configurable<SentinelConfig>, Ins
             target = SharedFunctions.getAttacker(heroapi, npcs, heroapi);
         }
 
+        if (target == null) {
+            clearAttackTargets();
+            return false;
+        }
+
         changeTarget(target);
 
         this.oldTarget = target;
 
-        return target != null;
+        return true;
+    }
+
+    private boolean shouldKeepOldTarget() {
+        if (this.oldTarget == null || !this.oldTarget.isValid() || this.sentinel == null) {
+            return false;
+        }
+
+        Entity sentinelTarget = this.sentinel.getTarget();
+        return sentinelTarget != null && sentinelTarget.getId() == this.oldTarget.getId();
+    }
+
+    private void clearAttackTargets() {
+        this.oldTarget = null;
+        this.isNpc = false;
+        this.attacker.setTarget(null);
+        this.shipAttacker.resetDefenseData();
     }
 
     private void changeTarget(Entity target) {

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "DmPlugin",
 	"author": "Dm94Dani",
-	"version": "2.11.1 beta 4",
+	"version": "2.11.1 beta 5",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0",
 	"basePackage": "com.deeme",


### PR DESCRIPTION
…down

Ensure old targets are only retained when the sentinel is actively attacking them. Clear attack targets consistently when no valid target exists or the cooldown period ends without a valid old target. This prevents stale target references and ensures proper attack state reset.

## Summary by Sourcery

Improve sentinel attack state handling by only retaining old targets while they are actively being attacked and consistently clearing attack targets when no valid target exists or cooldown expires without a valid target.

Bug Fixes:
- Prevent stale sentinel target references by clearing attack targets when cooldown elapses without a valid active target or when no new valid target is found.

Enhancements:
- Introduce helper methods to determine when to keep an old target and to centralize attack target clearing logic for more consistent sentinel behavior.