### PR TITLE
feat(mcp): add addresses resource for inspect tooling

### DIFF
--- a/src/main/java/com/deeme/tasks/mcp/AGENTS.md
+++ b/src/main/java/com/deeme/tasks/mcp/AGENTS.md
@@ -33,7 +33,7 @@ McpBridge            @Feature + Task + Configurable<McpConfig> + Installable. Wi
 │  ├─ ProfileListResource  bot://profiles
 │  ├─ ConfigValueResource  bot://config/value?path=...
 │  ├─ ConfigTreeResource   bot://config/tree
-│  ├─ InspectResource      bot://inspect?root=...&path=...&max_depth=...&max_items=... or ?address=0x...
+│  ├─ InspectResource      bot://inspect?address=0x... (address-based only)
 │  ├─ NpcConfigResource    bot://config/npc
 │  ├─ EntitiesResource     mcp://entities — live NPCs, players, pets, boxes, mines, portals
 │  ├─ PetResource          mcp://pet — PET gear, locator, stats
@@ -168,7 +168,6 @@ Self-check runner (no JUnit): `ObjectInspectorSelfCheck` — `java -ea -cp ... c
 | `bot://config/value?path=...`     | Config value reader                                  |
 | `bot://config/tree`               | Config tree navigator (supports path drilling)       |
 | `bot://config/npc`                | NPC configuration (list all or get by name)          |
-| `bot://inspect?root=...&path=...` | Object inspector (supports `max_depth`, `max_items`) |
 | `bot://inspect?address=0x...` | Address-based object inspector (mirrors DarkBot's address box) |
 | `conditions://schema`             | Condition DSL schema (all types, values, enums)      |
 | `mcp://log`                      | DarkBot session log reader (tail, filter, list)      |

--- a/src/main/java/com/deeme/tasks/mcp/AGENTS.md
+++ b/src/main/java/com/deeme/tasks/mcp/AGENTS.md
@@ -34,6 +34,7 @@ McpBridge            @Feature + Task + Configurable<McpConfig> + Installable. Wi
 │  ├─ ConfigValueResource  bot://config/value?path=...
 │  ├─ ConfigTreeResource   bot://config/tree
 │  ├─ InspectResource      bot://inspect?address=0x... (address-based only)
+│  ├─ AddressesResource    bot://addresses (managers/guis/facades addresses for bot://inspect)
 │  ├─ NpcConfigResource    bot://config/npc
 │  ├─ EntitiesResource     mcp://entities — live NPCs, players, pets, boxes, mines, portals
 │  ├─ PetResource          mcp://pet — PET gear, locator, stats
@@ -169,6 +170,7 @@ Self-check runner (no JUnit): `ObjectInspectorSelfCheck` — `java -ea -cp ... c
 | `bot://config/tree`               | Config tree navigator (supports path drilling)       |
 | `bot://config/npc`                | NPC configuration (list all or get by name)          |
 | `bot://inspect?address=0x...` | Address-based object inspector (mirrors DarkBot's address box) |
+| `bot://addresses`                 | Live addresses for managers/guis/facades (ready for `bot://inspect`)      |
 | `conditions://schema`             | Condition DSL schema (all types, values, enums)      |
 | `mcp://log`                      | DarkBot session log reader (tail, filter, list)      |
 

--- a/src/main/java/com/deeme/tasks/mcp/McpBridge.java
+++ b/src/main/java/com/deeme/tasks/mcp/McpBridge.java
@@ -109,7 +109,7 @@ public class McpBridge implements Task, Configurable<McpConfig>, Installable {
         protocol.registerResource(new ProfileListResource(configAPI));
         protocol.registerResource(new ConfigValueResource(configAPI, bot));
         protocol.registerResource(new ConfigTreeResource(configAPI));
-        protocol.registerResource(new InspectResource(bot, hero, stats, extensions, starSystem, configAPI));
+        protocol.registerResource(new InspectResource());
         protocol.registerResource(new NpcConfigResource(configAPI));
         protocol.registerResource(new ConditionSchemaResource());
 

--- a/src/main/java/com/deeme/tasks/mcp/McpBridge.java
+++ b/src/main/java/com/deeme/tasks/mcp/McpBridge.java
@@ -18,6 +18,7 @@ import com.deeme.tasks.mcp.resources.ModuleResource;
 import com.deeme.tasks.mcp.resources.NpcConfigResource;
 import com.deeme.tasks.mcp.resources.NpcEventResource;
 import com.deeme.tasks.mcp.resources.OreResource;
+import com.deeme.tasks.mcp.resources.PeekResource;
 import com.deeme.tasks.mcp.resources.PetResource;
 import com.deeme.tasks.mcp.resources.PluginResource;
 import com.deeme.tasks.mcp.resources.ProfileListResource;
@@ -111,6 +112,7 @@ public class McpBridge implements Task, Configurable<McpConfig>, Installable {
         protocol.registerResource(new ConfigValueResource(configAPI, bot));
         protocol.registerResource(new ConfigTreeResource(configAPI));
         protocol.registerResource(new InspectResource());
+        protocol.registerResource(new PeekResource());
         protocol.registerResource(new AddressesResource());
         protocol.registerResource(new NpcConfigResource(configAPI));
         protocol.registerResource(new ConditionSchemaResource());

--- a/src/main/java/com/deeme/tasks/mcp/McpBridge.java
+++ b/src/main/java/com/deeme/tasks/mcp/McpBridge.java
@@ -3,6 +3,7 @@ package com.deeme.tasks.mcp;
 import java.util.Arrays;
 
 import com.deeme.tasks.mcp.conditions.ConditionSchemaResource;
+import com.deeme.tasks.mcp.resources.AddressesResource;
 import com.deeme.tasks.mcp.resources.BotResource;
 import com.deeme.tasks.mcp.resources.BoosterResource;
 import com.deeme.tasks.mcp.resources.ConfigTreeResource;
@@ -110,6 +111,7 @@ public class McpBridge implements Task, Configurable<McpConfig>, Installable {
         protocol.registerResource(new ConfigValueResource(configAPI, bot));
         protocol.registerResource(new ConfigTreeResource(configAPI));
         protocol.registerResource(new InspectResource());
+        protocol.registerResource(new AddressesResource());
         protocol.registerResource(new NpcConfigResource(configAPI));
         protocol.registerResource(new ConditionSchemaResource());
 

--- a/src/main/java/com/deeme/tasks/mcp/resources/AddressesResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/AddressesResource.java
@@ -1,12 +1,13 @@
 package com.deeme.tasks.mcp.resources;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 
 /**
  * Catalog of live memory addresses for DarkBot core objects (managers,
@@ -28,6 +29,8 @@ public class AddressesResource implements McpResource {
   private static final String FACADE_PKG = "com.github.manolo8.darkbot.core.objects.facades.";
   private static final String GUI_BASE = "com.github.manolo8.darkbot.core.objects.Gui";
   private static final String GUI_PKG = "com.github.manolo8.darkbot.core.objects.gui.";
+  private static final String FLASH_MAP_CLASS = "com.github.manolo8.darkbot.core.objects.swf.FlashMap";
+  private static final String UPDATABLE_CLASS = "com.github.manolo8.darkbot.core.itf.Updatable";
 
   /** Field specs on {@code Main}: {fieldName, declaredTypeFqcn}. */
   private static final String[][] MANAGERS = {
@@ -89,6 +92,25 @@ public class AddressesResource implements McpResource {
       { "shipWarpProxy", FACADE_PKG + "ShipWarpProxy" },
   };
 
+  /**
+   * FacadeManager.proxies entries registered by key, not exposed as public
+   * fields.
+   */
+  private static final String[] PROXY_KEYS = {
+      "QuestProxy",
+  };
+
+  /**
+   * FacadeManager.mediators entries registered by key, not exposed as public
+   * fields.
+   */
+  private static final String[] MEDIATOR_KEYS = {
+      "seasonPass",
+      "diminish_quests",
+      "QuestGiverWindowMediator",
+      "battle_pass",
+  };
+
   private static final MethodType GET_ADDRESS_TYPE = MethodType.methodType(long.class);
 
   private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
@@ -128,6 +150,8 @@ public class AddressesResource implements McpResource {
     root.add("managers", collect(main, MANAGERS));
     root.add("guis", collect(guiManager, GUIS));
     root.add("facades", collect(facadeManager, FACADES));
+    root.add("proxies", collectFromFlashMap(facadeManager, "proxies", PROXY_KEYS));
+    root.add("mediators", collectFromFlashMap(facadeManager, "mediators", MEDIATOR_KEYS));
 
     return gson.toJson(root);
   }
@@ -148,6 +172,42 @@ public class AddressesResource implements McpResource {
         continue;
       }
       group.addProperty(spec[0], String.format("0x%x", address));
+    }
+    return group;
+  }
+
+  /**
+   * Resolve addresses for entries stored in a FacadeManager FlashMap
+   * ({@code proxies}/{@code mediators}), which are registered by key and
+   * not exposed as public fields. Each value is an {@code Updatable}
+   * whose {@code address} field points to the underlying game object.
+   */
+  private JsonObject collectFromFlashMap(Object facadeManager, String mapField, String[] keys) {
+    JsonObject group = new JsonObject();
+    if (facadeManager == null) {
+      return group;
+    }
+    try {
+      Class<?> flashMapClass = Class.forName(FLASH_MAP_CLASS);
+      MethodHandle getter = findGetter(facadeManager.getClass(), mapField, flashMapClass);
+      Object map = getter.invoke(facadeManager);
+      if (!(map instanceof Map)) {
+        return group;
+      }
+      Class<?> updatableClass = Class.forName(UPDATABLE_CLASS);
+      MethodHandle addrGetter = findGetter(updatableClass, "address", long.class);
+      for (String key : keys) {
+        Object entry = ((Map<?, ?>) map).get(key);
+        if (entry == null) {
+          continue;
+        }
+        long address = (long) addrGetter.invoke(entry);
+        if (address != 0L) {
+          group.addProperty(key, String.format("0x%x", address));
+        }
+      }
+    } catch (Throwable t) {
+      // FlashMap layout mismatch or field renamed — skip silently.
     }
     return group;
   }

--- a/src/main/java/com/deeme/tasks/mcp/resources/AddressesResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/AddressesResource.java
@@ -1,0 +1,213 @@
+package com.deeme.tasks.mcp.resources;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * Catalog of live memory addresses for DarkBot core objects (managers,
+ * GUIs, facades). Every address returned here can be fed straight into
+ * {@code bot://inspect?address=...} to read the object's slots.
+ *
+ * <p>
+ * Access to DarkBot internals is done through
+ * {@link java.lang.invoke.MethodHandle} exclusively, because
+ * PluginClassLoader blocks {@code java.lang.reflect.*} references in
+ * compiled bytecode. Objects that do not expose a {@code getAddress()}
+ * method are silently skipped.
+ * </p>
+ */
+public class AddressesResource implements McpResource {
+
+  private static final String MAIN_CLASS = "com.github.manolo8.darkbot.Main";
+  private static final String MGR_PKG = "com.github.manolo8.darkbot.core.manager.";
+  private static final String FACADE_PKG = "com.github.manolo8.darkbot.core.objects.facades.";
+  private static final String GUI_BASE = "com.github.manolo8.darkbot.core.objects.Gui";
+  private static final String GUI_PKG = "com.github.manolo8.darkbot.core.objects.gui.";
+
+  /** Field specs on {@code Main}: {fieldName, declaredTypeFqcn}. */
+  private static final String[][] MANAGERS = {
+      { "guiManager", MGR_PKG + "GuiManager" },
+      { "hero", MGR_PKG + "HeroManager" },
+      { "statsManager", MGR_PKG + "StatsManager" },
+      { "settingsManager", MGR_PKG + "SettingsManager" },
+      { "mapManager", MGR_PKG + "MapManager" },
+      { "facadeManager", MGR_PKG + "FacadeManager" },
+      { "repairManager", MGR_PKG + "RepairManager" },
+      { "effectManager", MGR_PKG + "EffectManager" },
+      { "pingManager", MGR_PKG + "PingManager" },
+      { "starManager", MGR_PKG + "StarManager" },
+  };
+
+  /** Field specs on {@code GuiManager}. */
+  private static final String[][] GUIS = {
+      { "lostConnection", GUI_BASE },
+      { "connecting", GUI_BASE },
+      { "quests", GUI_BASE },
+      { "monthlyDeluxe", GUI_BASE },
+      { "returnLogin", GUI_BASE },
+      { "minimap", GUI_BASE },
+      { "targetedOffers", GUI_BASE },
+      { "logout", GUI_PKG + "LogoutGui" },
+      { "eventProgress", GUI_BASE },
+      { "eternalGate", GUI_BASE },
+      { "blacklightGate", GUI_BASE },
+      { "astralGate", GUI_BASE },
+      { "astralSelection", GUI_BASE },
+      { "seasonPass", GUI_BASE },
+      { "refinement", GUI_PKG + "RefinementGui" },
+      { "oreTrade", GUI_PKG + "OreTradeGui" },
+      { "settingsGui", GUI_PKG + "SettingsGui" },
+      { "chat", GUI_PKG + "ChatGui" },
+      { "shipWarpGui", GUI_PKG + "ShipWarpGui" },
+      { "assembly", GUI_PKG + "AssemblyManager" },
+  };
+
+  /** Field specs on {@code FacadeManager}. */
+  private static final String[][] FACADES = {
+      { "log", FACADE_PKG + "LogMediator" },
+      { "chat", FACADE_PKG + "ChatProxy" },
+      { "stats", FACADE_PKG + "StatsProxy" },
+      { "escort", FACADE_PKG + "EscortProxy" },
+      { "booster", FACADE_PKG + "BoosterProxy" },
+      { "settings", FACADE_PKG + "SettingsProxy" },
+      { "slotBars", FACADE_PKG + "SlotBarsProxy" },
+      { "labyrinth", FACADE_PKG + "FrozenLabyrinthProxy" },
+      { "eternalGate", FACADE_PKG + "EternalGateProxy" },
+      { "blacklightGate", FACADE_PKG + "EternalBlacklightProxy" },
+      { "chrominEvent", FACADE_PKG + "ChrominProxy" },
+      { "astralGate", FACADE_PKG + "AstralGateProxy" },
+      { "highlight", FACADE_PKG + "HighlightProxy" },
+      { "spaceMapWindowProxy", FACADE_PKG + "SpaceMapWindowProxy" },
+      { "plutus", FACADE_PKG + "GauntletPlutusProxy" },
+      { "npcEventProxy", FACADE_PKG + "NpcEventProxy" },
+      { "worldBossOverview", FACADE_PKG + "WorldBossOverviewProxy" },
+      { "shipWarpProxy", FACADE_PKG + "ShipWarpProxy" },
+  };
+
+  private static final MethodType GET_ADDRESS_TYPE = MethodType.methodType(long.class);
+
+  private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+  private final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+  private volatile Object mainInstance;
+
+  @Override
+  public String getUri() {
+    return "bot://addresses";
+  }
+
+  @Override
+  public String getName() {
+    return "Memory Addresses";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Live memory addresses for DarkBot core objects (managers, "
+        + "GUIs, facades). Use any returned address with "
+        + "bot://inspect?address=... to read the object's slots.";
+  }
+
+  @Override
+  public String read(String uri) {
+    JsonObject root = new JsonObject();
+    Object main = getMainInstance();
+    if (main == null) {
+      root.addProperty("error", "DarkBot Main instance not available yet");
+      return gson.toJson(root);
+    }
+
+    Object guiManager = readField(main, "guiManager", MGR_PKG + "GuiManager");
+    Object facadeManager = readField(main, "facadeManager", MGR_PKG + "FacadeManager");
+
+    root.add("managers", collect(main, MANAGERS));
+    root.add("guis", collect(guiManager, GUIS));
+    root.add("facades", collect(facadeManager, FACADES));
+
+    return gson.toJson(root);
+  }
+
+  private JsonObject collect(Object container, String[][] specs) {
+    JsonObject group = new JsonObject();
+    if (container == null) {
+      return group;
+    }
+    for (String[] spec : specs) {
+      Object target = readField(container, spec[0], spec[1]);
+      if (target == null) {
+        continue;
+      }
+      Long address = addressOf(target);
+      if (address == null) {
+        // Object exposes no getAddress() — nothing to inspect.
+        continue;
+      }
+      group.addProperty(spec[0], String.format("0x%x", address));
+    }
+    return group;
+  }
+
+  private Object getMainInstance() {
+    Object cached = mainInstance;
+    if (cached != null) {
+      return cached;
+    }
+    try {
+      Class<?> mainClass = Class.forName(MAIN_CLASS);
+      MethodHandle getter = lookup.findStaticGetter(mainClass, "INSTANCE", mainClass);
+      Object instance = getter.invoke();
+      if (instance != null) {
+        mainInstance = instance;
+      }
+      return instance;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private Object readField(Object container, String name, String typeFqcn) {
+    try {
+      Class<?> type = Class.forName(typeFqcn);
+      MethodHandle getter = findGetter(container.getClass(), name, type);
+      return getter.invoke(container);
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  /**
+   * @return the address, or {@code null} if the object has no readable
+   *         {@code getAddress()}.
+   */
+  private Long addressOf(Object obj) {
+    try {
+      MethodHandle mh = findVirtual(obj.getClass(), "getAddress", GET_ADDRESS_TYPE);
+      return (long) mh.invoke(obj);
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private MethodHandle findGetter(Class<?> refc, String name, Class<?> type)
+      throws IllegalAccessException, NoSuchFieldException {
+    try {
+      return lookup.findGetter(refc, name, type);
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      return MethodHandles.privateLookupIn(refc, lookup).findGetter(refc, name, type);
+    }
+  }
+
+  private MethodHandle findVirtual(Class<?> refc, String name, MethodType type)
+      throws IllegalAccessException, NoSuchMethodException {
+    try {
+      return lookup.findVirtual(refc, name, type);
+    } catch (IllegalAccessException | NoSuchMethodException e) {
+      return MethodHandles.privateLookupIn(refc, lookup).findVirtual(refc, name, type);
+    }
+  }
+}

--- a/src/main/java/com/deeme/tasks/mcp/resources/InspectResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/InspectResource.java
@@ -2,41 +2,15 @@ package com.deeme.tasks.mcp.resources;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.deeme.tasks.mcp.util.MemoryInspector;
-import com.deeme.tasks.mcp.util.ObjectInspector;
-import eu.darkbot.api.managers.BotAPI;
-import eu.darkbot.api.managers.ConfigAPI;
-import eu.darkbot.api.managers.ExtensionsAPI;
-import eu.darkbot.api.managers.HeroAPI;
-import eu.darkbot.api.managers.StarSystemAPI;
-import eu.darkbot.api.managers.StatsAPI;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class InspectResource implements McpResource {
 
-    private static final int DEFAULT_MAX_DEPTH = 2;
-    private static final int DEFAULT_MAX_ITEMS = 25;
-    private static final int MAX_DEPTH_LIMIT = 5;
-    private static final int MAX_ITEMS_LIMIT = 100;
-
-    private final Map<String, Object> roots = new LinkedHashMap<>();
     private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
-
-    public InspectResource(BotAPI bot, HeroAPI hero, StatsAPI stats,
-            ExtensionsAPI extensions, StarSystemAPI starSystem, ConfigAPI configAPI) {
-        roots.put("bot", bot);
-        roots.put("hero", hero);
-        roots.put("stats", stats);
-        roots.put("extensions", extensions);
-        roots.put("star_system", starSystem);
-        roots.put("config", configAPI);
-    }
 
     @Override
     public String getUri() {
@@ -50,60 +24,25 @@ public class InspectResource implements McpResource {
 
     @Override
     public String getDescription() {
-        return "Inspect DarkBot runtime objects by reflection, similar to Object.inspector. "
-                + "Use root=...&path=... to navigate from a known root, or address=0x... to "
-                + "read an object at a specific memory address (like the DarkBot inspector's "
-                + "address box). Useful for AI-assisted debugging and discovery.";
+        return "Inspect DarkBot runtime objects by memory address, similar to "
+                + "DarkBot's ObjectInspector address box. Use address=0x... (or "
+                + "decimal) to read the object's slots directly out of process "
+                + "memory. Useful for AI-assisted debugging and discovery.";
     }
 
     @Override
     public String read(String uri) {
-        Map<String, String> params = parseQuery(uri);
-
-        String address = params.get("address");
-        if (address != null && !address.isEmpty()) {
-            return readByAddress(address);
-        }
-
-        String rootName = params.get("root");
-        if (rootName == null || rootName.isEmpty()) {
-            JsonObject err = new JsonObject();
-            err.addProperty("error", "Missing 'root' or 'address' parameter");
-            err.add("available_roots", availableRoots());
-            return gson.toJson(err);
-        }
-
-        String path = params.getOrDefault("path", "");
-        int maxDepth = boundedInteger(params.get("max_depth"), DEFAULT_MAX_DEPTH, 0, MAX_DEPTH_LIMIT);
-        int maxItems = boundedInteger(params.get("max_items"), DEFAULT_MAX_ITEMS, 1, MAX_ITEMS_LIMIT);
-
-        Object root = roots.get(rootName);
-        if (root == null) {
-            JsonObject err = new JsonObject();
-            err.addProperty("error", "Unknown root: " + rootName);
-            err.add("available_roots", availableRoots());
-            return gson.toJson(err);
-        }
-
-        ObjectInspector inspector = new ObjectInspector(maxDepth, maxItems);
-        JsonObject result = inspector.inspect(rootName, root, path);
-        result.add("available_roots", availableRoots());
-        return gson.toJson(result);
-    }
-
-    private String readByAddress(String address) {
+        String address = parseQuery(uri).get("address");
         JsonObject result = new MemoryInspector().inspect(address);
-        if (result.get("available_roots") == null) {
-            result.add("available_roots", availableRoots());
-        }
         return gson.toJson(result);
     }
 
     private Map<String, String> parseQuery(String uri) {
         Map<String, String> params = new HashMap<>();
         int qmark = uri.indexOf('?');
-        if (qmark < 0)
+        if (qmark < 0) {
             return params;
+        }
         String query = uri.substring(qmark + 1);
         for (String pair : query.split("&")) {
             int eq = pair.indexOf('=');
@@ -112,26 +51,5 @@ public class InspectResource implements McpResource {
             }
         }
         return params;
-    }
-
-    private JsonArray availableRoots() {
-        JsonArray array = new JsonArray();
-        for (String rootName : roots.keySet()) {
-            array.add(new JsonPrimitive(rootName));
-        }
-        return array;
-    }
-
-    private int boundedInteger(String value, int defaultValue, int minimum, int maximum) {
-        if (value == null || value.isEmpty())
-            return defaultValue;
-        try {
-            int parsed = Integer.parseInt(value);
-            if (parsed < minimum || parsed > maximum)
-                return defaultValue;
-            return parsed;
-        } catch (NumberFormatException e) {
-            return defaultValue;
-        }
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/resources/PeekResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/PeekResource.java
@@ -1,0 +1,250 @@
+package com.deeme.tasks.mcp.resources;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Generic raw-memory peeker: reads one or more primitive values at fixed
+ * offsets from a memory address. Complements {@code bot://inspect}, which
+ * only walks <em>named</em> AS3 trait slots — native fields like
+ * {@code Array.length} (offset 40) or {@code Vector.size} (offset 56) have
+ * no trait and need a raw read.
+ *
+ * <p>
+ * URI: {@code bot://peek?address=0x...&offsets=OFFSET:TYPE[;OFFSET:TYPE...]}
+ * <br>
+ * Types: {@code int uint long double bool string atom}.
+ * For {@code string}/{@code atom} the value at {@code address+offset} is
+ * treated as a pointer (atom-masked for {@code atom}) and dereferenced.
+ * </p>
+ *
+ * <p>
+ * Uses {@link java.lang.invoke.MethodHandle} exclusively — the DarkBot
+ * {@code PluginClassLoader} blocks {@code java.lang.reflect.*}.
+ * </p>
+ */
+public class PeekResource implements McpResource {
+
+    private static final String MAIN_CLASS = "com.github.manolo8.darkbot.Main";
+    private static final String IDARK_BOT_API_CLASS = "com.github.manolo8.darkbot.core.IDarkBotAPI";
+    private static final String BYTE_UTILS_CLASS = "com.github.manolo8.darkbot.core.utils.ByteUtils";
+
+    private static final long ATOM_MASK = resolveAtomMask();
+
+    private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+    private final Resolved resolved = Resolved.lazyResolve();
+
+    @Override
+    public String getUri() {
+        return "bot://peek";
+    }
+
+    @Override
+    public String getName() {
+        return "Memory Peek";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Read raw primitive values at fixed offsets from a memory "
+                + "address. Use for native AS3 fields with no trait slot "
+                + "(e.g. Array.length at +40). "
+                + "URI: bot://peek?address=0x...&offsets=40:int;56:int";
+    }
+
+    @Override
+    public String read(String uri) {
+        JsonObject result = new JsonObject();
+        Map<String, String> params = parseQuery(uri);
+        Optional<Long> parsed = parseAddress(params.get("address"));
+        if (!parsed.isPresent()) {
+            result.addProperty("error", "Missing or invalid 'address'");
+            return gson.toJson(result);
+        }
+        long address = parsed.get();
+        result.addProperty("address", String.format("0x%x", address));
+
+        String offsets = params.get("offsets");
+        if (offsets == null || offsets.isEmpty() || resolved == null) {
+            result.addProperty("error",
+                    offsets == null || offsets.isEmpty()
+                            ? "Missing 'offsets' (e.g. 40:int;56:int)"
+                            : "DarkBot API not reachable");
+            return gson.toJson(result);
+        }
+
+        JsonArray values = new JsonArray();
+        for (String spec : offsets.split("[;,]")) {
+            values.add(readOne(spec.trim(), address));
+        }
+        result.add("values", values);
+        return gson.toJson(result);
+    }
+
+    private JsonObject readOne(String spec, long base) {
+        JsonObject out = new JsonObject();
+        out.addProperty("spec", spec);
+        String[] parts = spec.split(":");
+        if (parts.length != 2) {
+            return error(out, "Bad spec, use offset:type");
+        }
+        long offset;
+        try {
+            offset = parts[0].startsWith("0x") || parts[0].startsWith("0X")
+                    ? Long.decode(parts[0])
+                    : Long.parseLong(parts[0]);
+        } catch (NumberFormatException e) {
+            return error(out, "Bad offset: " + parts[0]);
+        }
+        long addr = base + offset;
+        try {
+            switch (parts[1].toLowerCase()) {
+                case "int":
+                    out.add("value", new JsonPrimitive((int) resolved.readInt.invoke(resolved.api, addr)));
+                    break;
+                case "uint":
+                    out.add("value", new JsonPrimitive(
+                            Integer.toUnsignedString((int) resolved.readInt.invoke(resolved.api, addr))));
+                    break;
+                case "long":
+                    out.add("value", new JsonPrimitive(
+                            String.format("0x%x", (long) resolved.readLong.invoke(resolved.api, addr))));
+                    break;
+                case "double":
+                    out.add("value", new JsonPrimitive((double) resolved.readDouble.invoke(resolved.api, addr)));
+                    break;
+                case "bool":
+                case "boolean":
+                    out.add("value", new JsonPrimitive((int) resolved.readInt.invoke(resolved.api, addr) != 0));
+                    break;
+                case "atom": {
+                    long ptr = (long) resolved.readLong.invoke(resolved.api, addr) & ATOM_MASK;
+                    out.add("value", ptr == 0 ? new JsonPrimitive("null")
+                            : new JsonPrimitive(String.format("0x%x", ptr)));
+                    break;
+                }
+                case "string": {
+                    long ptr = (long) resolved.readLong.invoke(resolved.api, addr);
+                    if (ptr == 0) {
+                        out.add("value", new JsonPrimitive((String) null));
+                    } else {
+                        String s = (String) resolved.readStringDirect.invoke(ptr);
+                        out.add("value", new JsonPrimitive(s == null ? "null" : s));
+                    }
+                    break;
+                }
+                default:
+                    return error(out, "Unknown type: " + parts[1]);
+            }
+        } catch (Throwable t) {
+            return error(out, "read_error: " + t.getMessage());
+        }
+        return out;
+    }
+
+    private JsonObject error(JsonObject out, String message) {
+        out.addProperty("error", message);
+        return out;
+    }
+
+    private Map<String, String> parseQuery(String uri) {
+        Map<String, String> params = new HashMap<>();
+        int qmark = uri.indexOf('?');
+        if (qmark < 0) return params;
+        for (String pair : uri.substring(qmark + 1).split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq > 0) params.put(pair.substring(0, eq), pair.substring(eq + 1));
+        }
+        return params;
+    }
+
+    /** Parse hex (0x...) or decimal address string. */
+    private static Optional<Long> parseAddress(String text) {
+        if (text == null) return Optional.empty();
+        String trimmed = text.trim();
+        if (trimmed.isEmpty()) return Optional.empty();
+        try {
+            if (trimmed.startsWith("0x") || trimmed.startsWith("0X")) {
+                return Optional.of(Long.parseUnsignedLong(trimmed.substring(2), 16));
+            }
+            return Optional.of(Long.parseUnsignedLong(trimmed, 10));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static long resolveAtomMask() {
+        try {
+            Class<?> byteUtils = Class.forName(BYTE_UTILS_CLASS);
+            return (long) MethodHandles.lookup().findStaticGetter(byteUtils, "ATOM_MASK", long.class).invoke();
+        } catch (Throwable t) {
+            return ~7L;
+        }
+    }
+
+    private static final class Resolved {
+        final Object api;
+        final MethodHandle readInt;
+        final MethodHandle readLong;
+        final MethodHandle readDouble;
+        final MethodHandle readStringDirect;
+
+        private Resolved(Object api, MethodHandle readInt, MethodHandle readLong,
+                MethodHandle readDouble, MethodHandle readStringDirect) {
+            this.api = api;
+            this.readInt = readInt;
+            this.readLong = readLong;
+            this.readDouble = readDouble;
+            this.readStringDirect = readStringDirect;
+        }
+
+        static Resolved lazyResolve() {
+            try {
+                MethodHandles.Lookup lookup = MethodHandles.lookup();
+                Class<?> mainClass = Class.forName(MAIN_CLASS);
+                Class<?> apiClass = Class.forName(IDARK_BOT_API_CLASS);
+                Class<?> byteUtils = Class.forName(BYTE_UTILS_CLASS);
+                Object api = lookup.findStaticGetter(mainClass, "API", apiClass).invoke();
+                if (api == null)
+                    return null;
+                return new Resolved(api,
+                        findVirtual(lookup, apiClass, "readInt", int.class),
+                        findVirtual(lookup, apiClass, "readLong", long.class),
+                        findVirtual(lookup, apiClass, "readDouble", double.class),
+                        findStatic(lookup, byteUtils, "readStringDirect",
+                                MethodType.methodType(String.class, long.class)));
+            } catch (Throwable t) {
+                return null;
+            }
+        }
+
+        private static MethodHandle findVirtual(MethodHandles.Lookup l, Class<?> c, String n, Class<?> ret)
+                throws NoSuchMethodException, IllegalAccessException {
+            MethodType t = MethodType.methodType(ret, long.class);
+            try {
+                return l.findVirtual(c, n, t);
+            } catch (Throwable e) {
+                return MethodHandles.privateLookupIn(c, l).findVirtual(c, n, t);
+            }
+        }
+
+        private static MethodHandle findStatic(MethodHandles.Lookup l, Class<?> c, String n, MethodType t)
+                throws NoSuchMethodException, IllegalAccessException {
+            try {
+                return l.findStatic(c, n, t);
+            } catch (Throwable e) {
+                return MethodHandles.privateLookupIn(c, l).findStatic(c, n, t);
+            }
+        }
+    }
+}

--- a/src/main/java/com/deeme/tasks/mcp/util/MemoryInspector.java
+++ b/src/main/java/com/deeme/tasks/mcp/util/MemoryInspector.java
@@ -126,7 +126,7 @@ public final class MemoryInspector {
         }
         if (total > MAX_SLOTS) {
             JsonObject marker = new JsonObject();
-            marker.addProperty("truncated", true);
+            Json.put(marker, "truncated", true);
             marker.addProperty("included", included);
             marker.addProperty("total", total);
             marker.addProperty("reason", "max_slots");
@@ -182,7 +182,7 @@ public final class MemoryInspector {
                 }
                 JsonObject o = new JsonObject();
                 o.addProperty("address", String.format("0x%x", ptr));
-                o.addProperty("is_pointer", true);
+                Json.put(o, "is_pointer", true);
                 return o;
             }
         }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "DmPlugin",
 	"author": "Dm94Dani",
-	"version": "2.13.1 beta 1",
+	"version": "2.13.1 beta 2",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0",
 	"basePackage": "com.deeme",


### PR DESCRIPTION
## Summary by Sourcery

Add new MCP resources for memory inspection tooling and simplify inspect to address-based access only.

New Features:
- Introduce AddressesResource to expose live memory addresses for DarkBot managers, GUIs, facades, proxies and mediators.
- Add PeekResource to read primitive values at specified offsets from a given memory address.
- Limit InspectResource to memory-address based inspection only and register the new resources in McpBridge.

Enhancements:
- Update MemoryInspector JSON output to use the shared Json helper for certain flags.
- Refresh MCP agents documentation to describe the new addresses and peek capabilities and the updated inspect behavior.