### PR TITLE
feat(travel): add SmartBlTravel low-level travel behavior

### DIFF
--- a/src/main/java/com/deeme/behaviours/travel/FourFourRouter.java
+++ b/src/main/java/com/deeme/behaviours/travel/FourFourRouter.java
@@ -1,0 +1,126 @@
+package com.deeme.behaviours.travel;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.deeme.types.VerifierChecker;
+import com.deeme.types.backpage.Utils;
+
+import eu.darkbot.api.PluginAPI;
+import eu.darkbot.api.config.ConfigSetting;
+import eu.darkbot.api.extensions.Behavior;
+import eu.darkbot.api.extensions.FeatureInfo;
+import eu.darkbot.api.game.entities.Portal;
+import eu.darkbot.api.game.other.GameMap;
+import eu.darkbot.api.managers.AuthAPI;
+import eu.darkbot.api.managers.BotAPI;
+import eu.darkbot.api.managers.ConfigAPI;
+import eu.darkbot.api.managers.EntitiesAPI;
+import eu.darkbot.api.managers.ExtensionsAPI;
+import eu.darkbot.api.managers.HeroAPI;
+import eu.darkbot.api.managers.StarSystemAPI;
+import eu.darkbot.shared.modules.MapModule;
+
+/**
+ * Base behavior that, once activated, reroutes the ship to 4-4 before letting
+ * the normal travel resume. Subclasses decide when the reroute should trigger.
+ */
+public abstract class FourFourRouter implements Behavior {
+  private static final long CHECK_INTERVAL_MS = 500;
+
+  protected final PluginAPI api;
+  protected final HeroAPI hero;
+  protected final BotAPI bot;
+  protected final StarSystemAPI star;
+  protected final Collection<? extends Portal> portals;
+  protected final ConfigSetting<Integer> workingMap;
+
+  private boolean overrideActive = false;
+  private long nextCheck = 0;
+
+  protected FourFourRouter(PluginAPI api, HeroAPI hero, AuthAPI auth, ConfigAPI configApi, StarSystemAPI star) {
+    if (!Arrays.equals(VerifierChecker.class.getSigners(), getClass().getSigners())) {
+      throw new SecurityException();
+    }
+    VerifierChecker.requireAuthenticity(auth);
+
+    ExtensionsAPI extensionsAPI = api.requireAPI(ExtensionsAPI.class);
+    FeatureInfo<?> feature = extensionsAPI.getFeatureInfo(getClass());
+    Utils.discordCheck(feature, auth.getAuthId());
+    Utils.showDonateDialog(feature, auth.getAuthId());
+
+    this.api = api;
+    this.hero = hero;
+    this.bot = api.requireAPI(BotAPI.class);
+    this.star = star;
+    this.workingMap = configApi.requireConfig("general.working_map");
+
+    EntitiesAPI entities = api.requireAPI(EntitiesAPI.class);
+    this.portals = entities.getPortals();
+  }
+
+  @Override
+  public final void onTickBehavior() {
+    if (nextCheck > System.currentTimeMillis()) {
+      return;
+    }
+    nextCheck = System.currentTimeMillis() + CHECK_INTERVAL_MS;
+
+    if (hasConflictiveModuleInUse()) {
+      return;
+    }
+
+    GameMap current = star.getCurrentMap();
+    if (current == null) {
+      return;
+    }
+
+    GameMap target = star.findMap(workingMap.getValue()).orElse(null);
+    if (target == null) {
+      return;
+    }
+
+    if (overrideActive) {
+      if (isFourFour(current)) {
+        overrideActive = false;
+        return;
+      }
+      routeToFourFour(current);
+      return;
+    }
+
+    if (shouldRouteViaFourFour(current, target)) {
+      overrideActive = true;
+      routeToFourFour(current);
+    }
+  }
+
+  /**
+   * @return true when the current/target combination should trigger a reroute via 4-4.
+   */
+  protected abstract boolean shouldRouteViaFourFour(GameMap current, GameMap target);
+
+  private void routeToFourFour(GameMap current) {
+    GameMap fourFour = findFourFour();
+    if (fourFour != null && current != fourFour && !portals.isEmpty()) {
+      bot.setModule(api.requireInstance(MapModule.class)).setTarget(fourFour);
+    }
+  }
+
+  protected boolean isFourFour(GameMap map) {
+    return "4-4".equals(map.getShortName());
+  }
+
+  protected GameMap findFourFour() {
+    for (GameMap m : star.getMaps()) {
+      if (isFourFour(m)) {
+        return m;
+      }
+    }
+    return null;
+  }
+
+  private boolean hasConflictiveModuleInUse() {
+    return bot.getModule().getClass().getName().contains("CaptchaPicker");
+  }
+}

--- a/src/main/java/com/deeme/behaviours/travel/FourFourRouter.java
+++ b/src/main/java/com/deeme/behaviours/travel/FourFourRouter.java
@@ -96,7 +96,8 @@ public abstract class FourFourRouter implements Behavior {
   }
 
   /**
-   * @return true when the current/target combination should trigger a reroute via 4-4.
+   * @return true when the current/target combination should trigger a reroute via
+   *         4-4.
    */
   protected abstract boolean shouldRouteViaFourFour(GameMap current, GameMap target);
 
@@ -121,6 +122,7 @@ public abstract class FourFourRouter implements Behavior {
   }
 
   private boolean hasConflictiveModuleInUse() {
-    return bot.getModule().getClass().getName().contains("CaptchaPicker");
+    return bot.getModule() != null && bot.getModule().getClass() != null
+        && bot.getModule().getClass().getName().contains("CaptchaPicker");
   }
 }

--- a/src/main/java/com/deeme/behaviours/travel/SmartBlTravel.java
+++ b/src/main/java/com/deeme/behaviours/travel/SmartBlTravel.java
@@ -1,119 +1,33 @@
 package com.deeme.behaviours.travel;
 
-import java.util.Arrays;
-import java.util.Collection;
-
-import com.deeme.types.VerifierChecker;
-import com.deeme.types.backpage.Utils;
-
 import eu.darkbot.api.PluginAPI;
-import eu.darkbot.api.config.ConfigSetting;
-import eu.darkbot.api.extensions.Behavior;
 import eu.darkbot.api.extensions.Feature;
-import eu.darkbot.api.extensions.FeatureInfo;
-import eu.darkbot.api.game.entities.Portal;
 import eu.darkbot.api.game.other.GameMap;
 import eu.darkbot.api.managers.AuthAPI;
-import eu.darkbot.api.managers.BotAPI;
 import eu.darkbot.api.managers.ConfigAPI;
-import eu.darkbot.api.managers.EntitiesAPI;
-import eu.darkbot.api.managers.ExtensionsAPI;
 import eu.darkbot.api.managers.HeroAPI;
 import eu.darkbot.api.managers.StarSystemAPI;
 import eu.darkbot.api.managers.StatsAPI;
 import eu.darkbot.api.utils.Inject;
-import eu.darkbot.shared.modules.MapModule;
 
 @Feature(name = "Fix BL Travel", description = "Routes via 4-4 when traveling to enemy X-6/7/8 maps and ship level is too low for BL-to-BL portals")
-public class SmartBlTravel implements Behavior {
+public class SmartBlTravel extends FourFourRouter {
   private static final int BL_PORTAL_MIN_LEVEL = 25;
 
-  private final PluginAPI api;
-  private final BotAPI bot;
-  private final HeroAPI hero;
-  private final StarSystemAPI star;
   private final StatsAPI stats;
-  private final Collection<? extends Portal> portals;
-  private final ConfigSetting<Integer> workingMap;
-
-  private boolean overrideActive = false;
-  private long nextCheck = 0;
 
   @Inject
   public SmartBlTravel(PluginAPI api, HeroAPI hero, AuthAPI auth, ConfigAPI configApi,
       StarSystemAPI star, StatsAPI stats) {
-    if (!Arrays.equals(VerifierChecker.class.getSigners(), getClass().getSigners())) {
-      throw new SecurityException();
-    }
-    VerifierChecker.requireAuthenticity(auth);
-
-    ExtensionsAPI extensionsAPI = api.requireAPI(ExtensionsAPI.class);
-    FeatureInfo<?> feature = extensionsAPI.getFeatureInfo(this.getClass());
-    Utils.discordCheck(feature, auth.getAuthId());
-    Utils.showDonateDialog(feature, auth.getAuthId());
-
-    this.api = api;
-    this.bot = api.requireAPI(BotAPI.class);
-    this.hero = hero;
-    this.star = star;
+    super(api, hero, auth, configApi, star);
     this.stats = stats;
-    this.workingMap = configApi.requireConfig("general.working_map");
-
-    EntitiesAPI entities = api.requireAPI(EntitiesAPI.class);
-    this.portals = entities.getPortals();
   }
 
   @Override
-  public void onTickBehavior() {
-    if (nextCheck > System.currentTimeMillis()) {
-      return;
-    }
-    nextCheck = System.currentTimeMillis() + 500;
-
-    if (hasConflictiveModuleInUse()) {
-      return;
-    }
-
-    GameMap current = star.getCurrentMap();
-    if (current == null) {
-      return;
-    }
-
-    GameMap target = star.findMap(workingMap.getValue()).orElse(null);
-    if (target == null) {
-      return;
-    }
-
-    if (overrideActive) {
-      if (isFourFour(current)) {
-        overrideActive = false;
-        return;
-      }
-
-      GameMap fourFour = findFourFour();
-      if (fourFour != null && current != fourFour && !portals.isEmpty()) {
-        bot.setModule(api.requireInstance(MapModule.class)).setTarget(fourFour);
-      }
-      return;
-    }
-
-    if (stats.getLevel() < BL_PORTAL_MIN_LEVEL
+  protected boolean shouldRouteViaFourFour(GameMap current, GameMap target) {
+    return stats.getLevel() < BL_PORTAL_MIN_LEVEL
         && isEnemyHighMap(target)
-        && isOwnHighOrBl(current)) {
-      GameMap fourFour = findFourFour();
-      if (fourFour != null && current != fourFour && !portals.isEmpty()) {
-        overrideActive = true;
-        bot.setModule(api.requireInstance(MapModule.class)).setTarget(fourFour);
-      }
-    }
-  }
-
-  private boolean hasConflictiveModuleInUse() {
-    return bot.getModule().getClass().getName().contains("CaptchaPicker");
-  }
-
-  private boolean isFourFour(GameMap map) {
-    return "4-4".equals(map.getShortName());
+        && isOwnHighOrBl(current);
   }
 
   private boolean isEnemyHighMap(GameMap map) {
@@ -134,14 +48,5 @@ public class SmartBlTravel implements Behavior {
     }
     String prefix = String.valueOf(hero.getEntityInfo().getFaction().ordinal());
     return s.matches("^" + prefix + "-[678]$");
-  }
-
-  private GameMap findFourFour() {
-    for (GameMap m : star.getMaps()) {
-      if (isFourFour(m)) {
-        return m;
-      }
-    }
-    return null;
   }
 }

--- a/src/main/java/com/deeme/behaviours/travel/SmartBlTravel.java
+++ b/src/main/java/com/deeme/behaviours/travel/SmartBlTravel.java
@@ -10,7 +10,7 @@ import eu.darkbot.api.managers.StarSystemAPI;
 import eu.darkbot.api.managers.StatsAPI;
 import eu.darkbot.api.utils.Inject;
 
-@Feature(name = "Fix BL Travel", description = "Routes via 4-4 when traveling to enemy X-6/7/8 maps and ship level is too low for BL-to-BL portals")
+@Feature(name = "Fix BL Travel", description = "Routes via 4-4 when traveling to enemy X-6/7/8 maps and ship level is too low for BL-to-BL portals", enabledByDefault = true)
 public class SmartBlTravel extends FourFourRouter {
   private static final int BL_PORTAL_MIN_LEVEL = 25;
 

--- a/src/main/java/com/deeme/behaviours/travel/SmartBlTravel.java
+++ b/src/main/java/com/deeme/behaviours/travel/SmartBlTravel.java
@@ -1,0 +1,147 @@
+package com.deeme.behaviours.travel;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.deeme.types.VerifierChecker;
+import com.deeme.types.backpage.Utils;
+
+import eu.darkbot.api.PluginAPI;
+import eu.darkbot.api.config.ConfigSetting;
+import eu.darkbot.api.extensions.Behavior;
+import eu.darkbot.api.extensions.Feature;
+import eu.darkbot.api.extensions.FeatureInfo;
+import eu.darkbot.api.game.entities.Portal;
+import eu.darkbot.api.game.other.GameMap;
+import eu.darkbot.api.managers.AuthAPI;
+import eu.darkbot.api.managers.BotAPI;
+import eu.darkbot.api.managers.ConfigAPI;
+import eu.darkbot.api.managers.EntitiesAPI;
+import eu.darkbot.api.managers.ExtensionsAPI;
+import eu.darkbot.api.managers.HeroAPI;
+import eu.darkbot.api.managers.StarSystemAPI;
+import eu.darkbot.api.managers.StatsAPI;
+import eu.darkbot.api.utils.Inject;
+import eu.darkbot.shared.modules.MapModule;
+
+@Feature(name = "Fix BL Travel", description = "Routes via 4-4 when traveling to enemy X-6/7/8 maps and ship level is too low for BL-to-BL portals")
+public class SmartBlTravel implements Behavior {
+  private static final int BL_PORTAL_MIN_LEVEL = 25;
+
+  private final PluginAPI api;
+  private final BotAPI bot;
+  private final HeroAPI hero;
+  private final StarSystemAPI star;
+  private final StatsAPI stats;
+  private final Collection<? extends Portal> portals;
+  private final ConfigSetting<Integer> workingMap;
+
+  private boolean overrideActive = false;
+  private long nextCheck = 0;
+
+  @Inject
+  public SmartBlTravel(PluginAPI api, HeroAPI hero, AuthAPI auth, ConfigAPI configApi,
+      StarSystemAPI star, StatsAPI stats) {
+    if (!Arrays.equals(VerifierChecker.class.getSigners(), getClass().getSigners())) {
+      throw new SecurityException();
+    }
+    VerifierChecker.requireAuthenticity(auth);
+
+    ExtensionsAPI extensionsAPI = api.requireAPI(ExtensionsAPI.class);
+    FeatureInfo<?> feature = extensionsAPI.getFeatureInfo(this.getClass());
+    Utils.discordCheck(feature, auth.getAuthId());
+    Utils.showDonateDialog(feature, auth.getAuthId());
+
+    this.api = api;
+    this.bot = api.requireAPI(BotAPI.class);
+    this.hero = hero;
+    this.star = star;
+    this.stats = stats;
+    this.workingMap = configApi.requireConfig("general.working_map");
+
+    EntitiesAPI entities = api.requireAPI(EntitiesAPI.class);
+    this.portals = entities.getPortals();
+  }
+
+  @Override
+  public void onTickBehavior() {
+    if (nextCheck > System.currentTimeMillis()) {
+      return;
+    }
+    nextCheck = System.currentTimeMillis() + 500;
+
+    if (hasConflictiveModuleInUse()) {
+      return;
+    }
+
+    GameMap current = star.getCurrentMap();
+    if (current == null) {
+      return;
+    }
+
+    GameMap target = star.findMap(workingMap.getValue()).orElse(null);
+    if (target == null) {
+      return;
+    }
+
+    if (overrideActive) {
+      if (isFourFour(current)) {
+        overrideActive = false;
+        return;
+      }
+
+      GameMap fourFour = findFourFour();
+      if (fourFour != null && current != fourFour && !portals.isEmpty()) {
+        bot.setModule(api.requireInstance(MapModule.class)).setTarget(fourFour);
+      }
+      return;
+    }
+
+    if (stats.getLevel() < BL_PORTAL_MIN_LEVEL
+        && isEnemyHighMap(target)
+        && isOwnHighOrBl(current)) {
+      GameMap fourFour = findFourFour();
+      if (fourFour != null && current != fourFour && !portals.isEmpty()) {
+        overrideActive = true;
+        bot.setModule(api.requireInstance(MapModule.class)).setTarget(fourFour);
+      }
+    }
+  }
+
+  private boolean hasConflictiveModuleInUse() {
+    return bot.getModule().getClass().getName().contains("CaptchaPicker");
+  }
+
+  private boolean isFourFour(GameMap map) {
+    return "4-4".equals(map.getShortName());
+  }
+
+  private boolean isEnemyHighMap(GameMap map) {
+    String s = map.getShortName();
+    if (s == null || !s.matches("^[123]-[678]$")) {
+      return false;
+    }
+    return s.charAt(0) - '0' != hero.getEntityInfo().getFaction().ordinal();
+  }
+
+  private boolean isOwnHighOrBl(GameMap map) {
+    String s = map.getShortName();
+    if (s == null) {
+      return false;
+    }
+    if (s.toLowerCase().contains("bl")) {
+      return true;
+    }
+    String prefix = String.valueOf(hero.getEntityInfo().getFaction().ordinal());
+    return s.matches("^" + prefix + "-[678]$");
+  }
+
+  private GameMap findFourFour() {
+    for (GameMap m : star.getMaps()) {
+      if (isFourFour(m)) {
+        return m;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/deeme/behaviours/travel/SmartX1Travel.java
+++ b/src/main/java/com/deeme/behaviours/travel/SmartX1Travel.java
@@ -1,114 +1,30 @@
 package com.deeme.behaviours.travel;
 
-import java.util.Arrays;
-import java.util.Collection;
-
-import com.deeme.types.VerifierChecker;
-import com.deeme.types.backpage.Utils;
-
 import eu.darkbot.api.PluginAPI;
-import eu.darkbot.api.config.ConfigSetting;
-import eu.darkbot.api.extensions.Behavior;
 import eu.darkbot.api.extensions.Feature;
-import eu.darkbot.api.extensions.FeatureInfo;
-import eu.darkbot.api.game.entities.Portal;
 import eu.darkbot.api.game.other.GameMap;
 import eu.darkbot.api.managers.AuthAPI;
-import eu.darkbot.api.managers.BotAPI;
 import eu.darkbot.api.managers.ConfigAPI;
-import eu.darkbot.api.managers.EntitiesAPI;
-import eu.darkbot.api.managers.ExtensionsAPI;
 import eu.darkbot.api.managers.HeroAPI;
 import eu.darkbot.api.managers.StarSystemAPI;
 import eu.darkbot.api.utils.Inject;
-import eu.darkbot.shared.modules.MapModule;
 
 @Feature(name = "Fix X-1 Travel", description = "Route via 4-4 when traveling to X-1 from high maps")
-public class SmartX1Travel implements Behavior {
-  private final PluginAPI api;
-  private final BotAPI bot;
-  private final StarSystemAPI star;
-  private final Collection<? extends Portal> portals;
-  private final ConfigSetting<Integer> workingMap;
-
-  private boolean overrideActive = false;
-  private long nextCheck = 0;
+public class SmartX1Travel extends FourFourRouter {
 
   @Inject
   public SmartX1Travel(PluginAPI api, HeroAPI hero, AuthAPI auth, ConfigAPI configApi, StarSystemAPI star) {
-    if (!Arrays.equals(VerifierChecker.class.getSigners(), getClass().getSigners())) {
-      throw new SecurityException();
-    }
-    VerifierChecker.requireAuthenticity(auth);
-
-    ExtensionsAPI extensionsAPI = api.requireAPI(ExtensionsAPI.class);
-    FeatureInfo<?> feature = extensionsAPI.getFeatureInfo(this.getClass());
-    Utils.discordCheck(feature, auth.getAuthId());
-    Utils.showDonateDialog(feature, auth.getAuthId());
-
-    this.api = api;
-    this.bot = api.requireAPI(BotAPI.class);
-    this.star = star;
-    this.workingMap = configApi.requireConfig("general.working_map");
-
-    EntitiesAPI entities = api.requireAPI(EntitiesAPI.class);
-    this.portals = entities.getPortals();
+    super(api, hero, auth, configApi, star);
   }
 
   @Override
-  public void onTickBehavior() {
-    if (nextCheck > System.currentTimeMillis()) {
-      return;
-    }
-    nextCheck = System.currentTimeMillis() + 500;
-
-    if (hasConflictiveModuleInUse()) {
-      return;
-    }
-
-    GameMap current = star.getCurrentMap();
-    if (current == null) {
-      return;
-    }
-
-    GameMap target = star.findMap(workingMap.getValue()).orElse(null);
-    if (target == null) {
-      return;
-    }
-
-    if (overrideActive) {
-      if (isFourFour(current)) {
-        overrideActive = false;
-        return;
-      }
-
-      GameMap fourFour = findFourFour();
-      if (fourFour != null && current != fourFour && !portals.isEmpty()) {
-        bot.setModule(api.requireInstance(MapModule.class)).setTarget(fourFour);
-      }
-      return;
-    }
-
-    if (isX1(target) && isHighMap(current)) {
-      GameMap fourFour = findFourFour();
-      if (fourFour != null && current != fourFour && !portals.isEmpty()) {
-        overrideActive = true;
-        bot.setModule(api.requireInstance(MapModule.class)).setTarget(fourFour);
-      }
-    }
-  }
-
-  private boolean hasConflictiveModuleInUse() {
-    return bot.getModule().getClass().getName().contains("CaptchaPicker");
+  protected boolean shouldRouteViaFourFour(GameMap current, GameMap target) {
+    return isX1(target) && isHighMap(current);
   }
 
   private boolean isX1(GameMap map) {
     String s = map.getShortName();
     return s.matches("^[123]-[12]$");
-  }
-
-  private boolean isFourFour(GameMap map) {
-    return "4-4".equals(map.getShortName());
   }
 
   private boolean isHighMap(GameMap map) {
@@ -119,16 +35,6 @@ public class SmartX1Travel implements Behavior {
     if (s.matches("^[123]-[678]$")) {
       return true;
     }
-    String l = s.toLowerCase();
-    return l.contains("bl");
-  }
-
-  private GameMap findFourFour() {
-    for (GameMap m : star.getMaps()) {
-      if (isFourFour(m)) {
-        return m;
-      }
-    }
-    return null;
+    return s.toLowerCase().contains("bl");
   }
 }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "DmPlugin",
 	"author": "Dm94Dani",
-	"version": "2.13.1 beta 4",
+	"version": "2.13.1 beta 5",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0",
 	"basePackage": "com.deeme",

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "DmPlugin",
 	"author": "Dm94Dani",
-	"version": "2.13.1 beta 3",
+	"version": "2.13.1 beta 4",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0",
 	"basePackage": "com.deeme",
@@ -35,7 +35,8 @@
 		"com.deeme.behaviours.antitrain.AntiTrain",
 		"com.deeme.behaviours.urgentdetector.UrgentDetector",
 		"com.deeme.behaviours.bootykeymanager.BootyKeyCollectorManager",
-		"com.deeme.behaviours.travel.SmartX1Travel"
+		"com.deeme.behaviours.travel.SmartX1Travel",
+		"com.deeme.behaviours.travel.SmartBlTravel"
 	],
 	"donation": "https://ko-fi.com/deeme",
 	"discord": "https://discord.gg/GPRTRRZJPw",


### PR DESCRIPTION
Add SmartBlTravel behavior that routes via 4-4 map when traveling to enemy X-6/7/8 maps and the ship's level is below 25, bypassing direct BL-to-BL portals. Update plugin version to 2.13.1 beta 4 and register the new behavior in plugin.json.

## Summary by Sourcery

Improve travel routing by adding level-aware enemy BL navigation and consolidating 4-4 rerouting behavior.

New Features:
- Add smart low-level travel routing that uses 4-4 when traveling from allied high-level or BL maps to enemy X-6/7/8 maps.

Bug Fixes:
- Prevent ships below the BL portal level requirement from attempting direct BL-to-BL travel.

Enhancements:
- Extract shared 4-4 rerouting and travel interception logic into a reusable base behavior.
- Refactor X-1 travel behavior to use the shared 4-4 routing implementation.