### PR TITLE
fix: avoid stripped Gson addProperty overloads in MCP

### DIFF
--- a/src/main/java/com/deeme/tasks/mcp/conditions/ConditionSchemaResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/conditions/ConditionSchemaResource.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.conditions;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -16,6 +18,7 @@ public class ConditionSchemaResource implements McpResource {
 
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     private static final String DARKBOT_PKG = "com.github.manolo8.darkbot.config.actions";
+    private static final String DESCRIPTION_KEY = "description";
 
     private volatile String cachedSchema;
     private volatile String cachedError;
@@ -49,7 +52,7 @@ public class ConditionSchemaResource implements McpResource {
             return json;
         } catch (Exception e) {
             JsonObject err = new JsonObject();
-            err.addProperty("error", "Failed to load condition schema: " + e.getMessage());
+            Json.put(err, "error", "Failed to load condition schema: " + e.getMessage());
             String json = GSON.toJson(err);
             cachedError = json;
             return json;
@@ -58,16 +61,16 @@ public class ConditionSchemaResource implements McpResource {
 
     private JsonObject buildSchema() throws Exception {
         JsonObject schema = new JsonObject();
-        schema.addProperty("format", "Condition DSL uses function-call syntax: name(arg1, arg2, ...)");
-        schema.addProperty("description",
+        Json.put(schema, "format", "Condition DSL uses function-call syntax: name(arg1, arg2, ...)");
+        Json.put(schema, DESCRIPTION_KEY,
                 "Conditions are used in SAB config and Extra Actions. " +
                         "They return ALLOW, DENY, or ABSTAIN (three-valued logic). " +
                         "ABSTAIN acts as neutral (not DENY).");
 
         JsonObject results = new JsonObject();
-        results.addProperty("ALLOW", "Condition met (true)");
-        results.addProperty("DENY", "Condition failed (false)");
-        results.addProperty("ABSTAIN", "Neutral - data unavailable, treated as not-DENY");
+        Json.put(results, "ALLOW", "Condition met (true)");
+        Json.put(results, "DENY", "Condition failed (false)");
+        Json.put(results, "ABSTAIN", "Neutral - data unavailable, treated as not-DENY");
         schema.add("result_types", results);
 
         Map<String, Object> valuesMap = getValuesMap();
@@ -126,18 +129,18 @@ public class ConditionSchemaResource implements McpResource {
         Object params = invoke(getPar, meta);
 
         String name = callAnnotationMethod(valueData, "name", lookup);
-        String description = callAnnotationMethod(valueData, "description", lookup);
+        String description = callAnnotationMethod(valueData, DESCRIPTION_KEY, lookup);
         String example = callAnnotationMethod(valueData, "example", lookup);
 
         JsonObject item = new JsonObject();
-        item.addProperty("name", name);
-        item.addProperty("description", description);
-        item.addProperty("example", example);
-        item.addProperty("returnType", type.getSimpleName());
-        item.addProperty("className", clazz.getSimpleName());
+        Json.put(item, "name", name);
+        Json.put(item, DESCRIPTION_KEY, description);
+        Json.put(item, "example", example);
+        Json.put(item, "returnType", type.getSimpleName());
+        Json.put(item, "className", clazz.getSimpleName());
 
         Class<?> parserClass = Class.forName(DARKBOT_PKG + ".Parser");
-        item.addProperty("customParser", parserClass.isAssignableFrom(clazz));
+        Json.put(item, "customParser", parserClass.isAssignableFrom(clazz));
 
         JsonArray paramList = new JsonArray();
         if (params != null) {
@@ -178,8 +181,8 @@ public class ConditionSchemaResource implements McpResource {
         String fieldName = (String) invoke(getName, field);
 
         JsonObject p = new JsonObject();
-        p.addProperty("name", fieldName);
-        p.addProperty("type", pType.getSimpleName());
+        Json.put(p, "name", fieldName);
+        Json.put(p, "type", pType.getSimpleName());
 
         if (pType.isEnum()) {
             JsonArray values = new JsonArray();

--- a/src/main/java/com/deeme/tasks/mcp/resources/AddressesResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/AddressesResource.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.resources;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -140,7 +142,7 @@ public class AddressesResource implements McpResource {
     JsonObject root = new JsonObject();
     Object main = getMainInstance();
     if (main == null) {
-      root.addProperty("error", "DarkBot Main instance not available yet");
+      Json.put(root, "error", "DarkBot Main instance not available yet");
       return gson.toJson(root);
     }
 
@@ -171,7 +173,7 @@ public class AddressesResource implements McpResource {
         // Object exposes no getAddress() — nothing to inspect.
         continue;
       }
-      group.addProperty(spec[0], String.format("0x%x", address));
+      Json.put(group, spec[0], String.format("0x%x", address));
     }
     return group;
   }
@@ -203,7 +205,7 @@ public class AddressesResource implements McpResource {
         }
         long address = (long) addrGetter.invoke(entry);
         if (address != 0L) {
-          group.addProperty(key, String.format("0x%x", address));
+          Json.put(group, key, String.format("0x%x", address));
         }
       }
     } catch (Throwable t) {

--- a/src/main/java/com/deeme/tasks/mcp/resources/BoosterResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/BoosterResource.java
@@ -44,13 +44,13 @@ public class BoosterResource implements McpResource {
         for (BoosterAPI.Booster b : boosters.getBoosters()) {
             if (b == null) continue;
             JsonObject o = new JsonObject();
-            o.addProperty("category", b.getCategory());
-            o.addProperty("name", b.getName());
+            Json.put(o, "category", b.getCategory());
+            Json.put(o, "name", b.getName());
             Json.put(o, "amount_percent", Math.round(b.getAmount() * 10000.0) / 100.0);
             Json.put(o, "remaining_seconds", Math.round(b.getRemainingTime() * 100.0) / 100.0);
             if (b.getType() != null) {
-                o.addProperty("type", b.getType().name());
-                o.addProperty("short", b.getSmall());
+                Json.put(o, "type", b.getType().name());
+                Json.put(o, "short", b.getSmall());
             }
             arr.add(o);
         }

--- a/src/main/java/com/deeme/tasks/mcp/resources/BotResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/BotResource.java
@@ -38,13 +38,13 @@ public class BotResource implements McpResource {
         JsonObject obj = new JsonObject();
         Json.put(obj, "running", bot.isRunning());
         Json.put(obj, "paused", !bot.isRunning());
-        obj.addProperty("module_name", bot.getModule() != null ? bot.getModule().getClass().getSimpleName() : "(none)");
+        Json.put(obj, "module_name", bot.getModule() != null ? bot.getModule().getClass().getSimpleName() : "(none)");
         if (starSystem.getCurrentMap() != null) {
             Json.put(obj, "map_id", starSystem.getCurrentMap().getId());
-            obj.addProperty("map_name", starSystem.getCurrentMap().getName());
+            Json.put(obj, "map_name", starSystem.getCurrentMap().getName());
         }
         Json.put(obj, "tick_time_ms", Math.round(bot.getTickTime() * 100.0) / 100.0);
-        obj.addProperty("bot_version", bot.getVersion().toString());
+        Json.put(obj, "bot_version", bot.getVersion().toString());
         return gson.toJson(obj);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/resources/ConfigTreeResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/ConfigTreeResource.java
@@ -54,7 +54,7 @@ public class ConfigTreeResource implements McpResource {
 
         if (setting == null) {
             JsonObject err = new JsonObject();
-            err.addProperty("error", "Config path not found: " + path);
+            Json.put(err, "error", "Config path not found: " + path);
             return gson.toJson(err);
         }
 
@@ -98,16 +98,16 @@ public class ConfigTreeResource implements McpResource {
         Map<String, ConfigSetting<?>> children = parent.getChildren();
 
         JsonObject result = new JsonObject();
-        result.addProperty("path", path.isEmpty() ? "(root)" : path);
-        result.addProperty("type", "parent");
+        Json.put(result, "path", path.isEmpty() ? "(root)" : path);
+        Json.put(result, "type", "parent");
 
         if (children == null || children.isEmpty()) {
-            result.addProperty("child_count", 0);
+            Json.put(result, "child_count", 0);
             result.add("children", new JsonArray());
             return gson.toJson(result);
         }
 
-        result.addProperty("child_count", children.size());
+        Json.put(result, "child_count", children.size());
 
         JsonArray arr = new JsonArray();
         int count = 0;
@@ -120,12 +120,12 @@ public class ConfigTreeResource implements McpResource {
             boolean isParent = child instanceof ConfigSetting.Parent;
 
             JsonObject item = new JsonObject();
-            item.addProperty("name", entry.getKey());
-            item.addProperty("type", isParent ? "parent" : friendlyTypeName(child.getType()));
+            Json.put(item, "name", entry.getKey());
+            Json.put(item, "type", isParent ? "parent" : friendlyTypeName(child.getType()));
 
             if (isParent) {
                 Map<String, ConfigSetting<?>> sub = ((ConfigSetting.Parent) child).getChildren();
-                item.addProperty("child_count", sub != null ? sub.size() : 0);
+                Json.put(item, "child_count", sub != null ? sub.size() : 0);
             } else {
                 Object val = child.getValue();
                 if (val != null) {
@@ -135,7 +135,7 @@ public class ConfigTreeResource implements McpResource {
 
             String desc = child.getDescription();
             if (desc != null && !desc.isEmpty()) {
-                item.addProperty("description", desc);
+                Json.put(item, "description", desc);
             }
 
             arr.add(item);
@@ -144,8 +144,8 @@ public class ConfigTreeResource implements McpResource {
         if (children.size() > MAX_DISPLAY_ITEMS) {
             JsonObject truncated = new JsonObject();
             Json.put(truncated, "truncated", true);
-            truncated.addProperty("included", count);
-            truncated.addProperty("total", children.size());
+            Json.put(truncated, "included", count);
+            Json.put(truncated, "total", children.size());
             arr.add(truncated);
         }
 
@@ -155,8 +155,8 @@ public class ConfigTreeResource implements McpResource {
 
     private String describeLeaf(String path, ConfigSetting<?> setting) {
         JsonObject result = new JsonObject();
-        result.addProperty("path", path);
-        result.addProperty("type", friendlyTypeName(setting.getType()));
+        Json.put(result, "path", path);
+        Json.put(result, "type", friendlyTypeName(setting.getType()));
 
         Object value = setting.getValue();
         if (value != null) {
@@ -165,7 +165,7 @@ public class ConfigTreeResource implements McpResource {
 
         String desc = setting.getDescription();
         if (desc != null && !desc.isEmpty()) {
-            result.addProperty("description", desc);
+            Json.put(result, "description", desc);
         }
 
         Class<?> type = setting.getType();
@@ -197,19 +197,19 @@ public class ConfigTreeResource implements McpResource {
 
             Object min = setting.getMetadata("min");
             if (min instanceof Number) {
-                c.addProperty("min", ((Number) min).doubleValue());
+                Json.put(c, "min", ((Number) min).doubleValue());
                 hasAny = true;
             }
 
             Object max = setting.getMetadata("max");
             if (max instanceof Number) {
-                c.addProperty("max", ((Number) max).doubleValue());
+                Json.put(c, "max", ((Number) max).doubleValue());
                 hasAny = true;
             }
 
             Object step = setting.getMetadata("step");
             if (step instanceof Number) {
-                c.addProperty("step", ((Number) step).doubleValue());
+                Json.put(c, "step", ((Number) step).doubleValue());
                 hasAny = true;
             }
 

--- a/src/main/java/com/deeme/tasks/mcp/resources/ConfigValueResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/ConfigValueResource.java
@@ -42,7 +42,7 @@ public class ConfigValueResource implements McpResource {
 
         if (path.isEmpty()) {
             JsonObject result = new JsonObject();
-            result.addProperty("module",
+            Json.put(result, "module",
                     bot.getModule() != null ? bot.getModule().getClass().getSimpleName() : "(none)");
             Json.put(result, "running", bot.isRunning());
             return gson.toJson(result);
@@ -51,13 +51,13 @@ public class ConfigValueResource implements McpResource {
         try {
             Object value = configAPI.getConfigValue(path);
             JsonObject result = new JsonObject();
-            result.addProperty("path", path);
+            Json.put(result, "path", path);
             result.add("value", gson.toJsonTree(value));
             return result.toString();
         } catch (Exception e) {
             JsonObject err = new JsonObject();
-            err.addProperty("error", "Path not found: " + path);
-            err.addProperty("details", e.getMessage());
+            Json.put(err, "error", "Path not found: " + path);
+            Json.put(err, "details", e.getMessage());
             return err.toString();
         }
     }

--- a/src/main/java/com/deeme/tasks/mcp/resources/EntitiesResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/EntitiesResource.java
@@ -141,10 +141,10 @@ public class EntitiesResource implements McpResource {
 
   private JsonObject playerExtra(Player p) {
     JsonObject o = new JsonObject();
-    o.addProperty("ship_type", p.getShipType());
+    Json.put(o, "ship_type", p.getShipType());
     Json.put(o, "has_pet", p.hasPet());
     if (p.getFormation() != null)
-      o.addProperty("formation", p.getFormation().name());
+      Json.put(o, "formation", p.getFormation().name());
     return o;
   }
 
@@ -157,8 +157,8 @@ public class EntitiesResource implements McpResource {
 
   private JsonObject boxJson(Box b) {
     JsonObject o = baseEntity(b, "box");
-    o.addProperty("type_name", b.getTypeName());
-    o.addProperty("hash", b.getHash());
+    Json.put(o, "type_name", b.getTypeName());
+    Json.put(o, "hash", b.getHash());
     return o;
   }
 
@@ -166,10 +166,10 @@ public class EntitiesResource implements McpResource {
     JsonObject o = baseEntity(p, "portal");
     Json.put(o, "type_id", p.getTypeId());
     if (p.getPortalType() != null)
-      o.addProperty("portal_type", p.getPortalType().name());
+      Json.put(o, "portal_type", p.getPortalType().name());
     p.getTargetMap().ifPresent(m -> {
       Json.put(o, "target_map_id", m.getId());
-      o.addProperty("target_map_name", m.getName());
+      Json.put(o, "target_map_name", m.getName());
     });
     Json.put(o, "jumping", p.isJumping());
     return o;
@@ -177,7 +177,7 @@ public class EntitiesResource implements McpResource {
 
   private JsonObject baseEntity(Entity e, String type) {
     JsonObject o = new JsonObject();
-    o.addProperty("type", type);
+    Json.put(o, "type", type);
     Json.put(o, "id", e.getId());
     Json.put(o, "x", round(e.getX()));
     Json.put(o, "y", round(e.getY()));

--- a/src/main/java/com/deeme/tasks/mcp/resources/GroupResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/GroupResource.java
@@ -57,7 +57,7 @@ public class GroupResource implements McpResource {
             if (m == null) continue;
             JsonObject mo = new JsonObject();
             Json.put(mo, "id", m.getId());
-            mo.addProperty("username", m.getUsername());
+            Json.put(mo, "username", m.getUsername());
             Json.put(mo, "map_id", m.getMapId());
             Json.put(mo, "level", m.getLevel());
             Json.put(mo, "leader", m.isLeader());
@@ -82,9 +82,9 @@ public class GroupResource implements McpResource {
             Json.put(io, "incoming", inv.isIncoming());
             Json.put(io, "valid", inv.isValid());
             if (inv.getInviter() != null)
-                io.addProperty("inviter", inv.getInviter().getUsername());
+                Json.put(io, "inviter", inv.getInviter().getUsername());
             if (inv.getInvited() != null)
-                io.addProperty("invited", inv.getInvited().getUsername());
+                Json.put(io, "invited", inv.getInvited().getUsername());
             invites.add(io);
         }
         obj.add("invites", invites);

--- a/src/main/java/com/deeme/tasks/mcp/resources/HeroResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/HeroResource.java
@@ -58,15 +58,15 @@ public class HeroResource implements McpResource {
 
         if (starSystem.getCurrentMap() != null) {
             Json.put(obj, "map_id", starSystem.getCurrentMap().getId());
-            obj.addProperty("map_name", starSystem.getCurrentMap().getName());
+            Json.put(obj, "map_name", starSystem.getCurrentMap().getName());
         }
 
         if (hero.getConfiguration() != null) {
             Json.put(obj, "config", hero.getConfiguration().ordinal());
-            obj.addProperty("config_name", hero.getConfiguration().name());
+            Json.put(obj, "config_name", hero.getConfiguration().name());
         }
         if (hero.getFormation() != null) {
-            obj.addProperty("formation", hero.getFormation().name());
+            Json.put(obj, "formation", hero.getFormation().name());
         }
 
         Lockable target = hero.getLocalTarget();

--- a/src/main/java/com/deeme/tasks/mcp/resources/InventoryResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/InventoryResource.java
@@ -47,8 +47,8 @@ public class InventoryResource implements McpResource {
         for (InventoryAPI.Item item : inventory.getItems(waitMs)) {
             if (item == null) continue;
             JsonObject o = new JsonObject();
-            o.addProperty("loot_id", item.getLootId());
-            o.addProperty("name", item.getName());
+            Json.put(o, "loot_id", item.getLootId());
+            Json.put(o, "name", item.getName());
             Json.put(o, "amount", Math.round(item.getAmount() * 100.0) / 100.0);
             arr.add(o);
         }

--- a/src/main/java/com/deeme/tasks/mcp/resources/LogResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/LogResource.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.resources;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -55,6 +57,7 @@ public class LogResource implements McpResource {
   // the response bounded for huge logs; user can still use `tail` to
   // shrink the returned line count further.
   private static final int MAX_BYTES = 1_048_576; // 1 MiB
+  private static final String SIZE_BYTES_KEY = "size_bytes";
 
   private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
   private final Resolved resolved = Resolved.lazyResolve();
@@ -103,11 +106,11 @@ public class LogResource implements McpResource {
     }
 
     JsonObject result = new JsonObject();
-    result.addProperty("file", logFile.getFileName().toString());
-    result.addProperty("path", logFile.toString());
+    Json.put(result, "file", logFile.getFileName().toString());
+    Json.put(result, "path", logFile.toString());
 
     if (!Files.exists(logFile)) {
-      result.addProperty("error", "Log file not found");
+      Json.put(result, "error", "Log file not found");
       return gson.toJson(result);
     }
 
@@ -117,13 +120,13 @@ public class LogResource implements McpResource {
     } catch (IOException e) {
       return gson.toJson(error("size_error", e.getMessage()));
     }
-    result.addProperty("size_bytes", size);
+    Json.put(result, SIZE_BYTES_KEY, size);
 
     List<String> lines = readTail(logFile, tail, pattern);
-    result.addProperty("returned_lines", lines.size());
-    result.addProperty("tail", tail);
+    Json.put(result, "returned_lines", lines.size());
+    Json.put(result, "tail", tail);
     if (pattern != null) {
-      result.addProperty("pattern", pattern);
+      Json.put(result, "pattern", pattern);
     }
 
     JsonArray arr = new JsonArray();
@@ -152,7 +155,7 @@ public class LogResource implements McpResource {
       return gson.toJson(error("log_folder_missing", "LOG_FOLDER is null"));
     }
 
-    result.addProperty("folder", folder.toString());
+    Json.put(result, "folder", folder.toString());
     JsonArray arr = new JsonArray();
 
     if (Files.exists(folder)) {
@@ -170,16 +173,16 @@ public class LogResource implements McpResource {
 
   private JsonObject fileInfo(Path p) {
     JsonObject obj = new JsonObject();
-    obj.addProperty("name", p.getFileName().toString());
+    Json.put(obj, "name", p.getFileName().toString());
     try {
-      obj.addProperty("size_bytes", Files.size(p));
+      Json.put(obj, SIZE_BYTES_KEY, Files.size(p));
     } catch (IOException e) {
-      obj.addProperty("size_bytes", -1);
+      Json.put(obj, SIZE_BYTES_KEY, -1);
     }
     try {
-      obj.addProperty("modified", Files.getLastModifiedTime(p).toString());
+      Json.put(obj, "modified", Files.getLastModifiedTime(p).toString());
     } catch (IOException e) {
-      obj.addProperty("modified", "");
+      Json.put(obj, "modified", "");
     }
     return obj;
   }
@@ -254,10 +257,10 @@ public class LogResource implements McpResource {
 
   private JsonObject error(String code, String message) {
     JsonObject err = new JsonObject();
-    err.addProperty("code", code);
-    err.addProperty("message", message == null ? "" : message);
+    Json.put(err, "code", code);
+    Json.put(err, "message", message == null ? "" : message);
     JsonObject obj = new JsonObject();
-    obj.addProperty("error", code);
+    Json.put(obj, "error", code);
     obj.add("details", err);
     return obj;
   }

--- a/src/main/java/com/deeme/tasks/mcp/resources/ModuleResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/ModuleResource.java
@@ -41,23 +41,23 @@ public class ModuleResource implements McpResource {
         Json.put(obj, "running", bot.isRunning());
 
         if (module != null) {
-            obj.addProperty("module_name", module.getClass().getSimpleName());
-            obj.addProperty("module_class", module.getClass().getName());
+            Json.put(obj, "module_name", module.getClass().getSimpleName());
+            Json.put(obj, "module_class", module.getClass().getName());
 
             String status = module.getStatus();
             if (status != null)
-                obj.addProperty("status", status);
+                Json.put(obj, "status", status);
 
             String stoppedStatus = module.getStoppedStatus();
             if (stoppedStatus != null)
-                obj.addProperty("stopped_status", stoppedStatus);
+                Json.put(obj, "stopped_status", stoppedStatus);
         } else {
-            obj.addProperty("module_name", "(none)");
+            Json.put(obj, "module_name", "(none)");
         }
 
         if (starSystem.getCurrentMap() != null) {
             Json.put(obj, "map_id", starSystem.getCurrentMap().getId());
-            obj.addProperty("map_name", starSystem.getCurrentMap().getName());
+            Json.put(obj, "map_name", starSystem.getCurrentMap().getName());
         }
 
         return gson.toJson(obj);

--- a/src/main/java/com/deeme/tasks/mcp/resources/NpcConfigResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/NpcConfigResource.java
@@ -47,7 +47,7 @@ public class NpcConfigResource implements McpResource {
 
         if (npcInfos == null) {
             JsonObject result = new JsonObject();
-            result.addProperty("npc_count", 0);
+            Json.put(result, "npc_count", 0);
             result.add("npcs", new JsonArray());
             return gson.toJson(result);
         }
@@ -61,23 +61,23 @@ public class NpcConfigResource implements McpResource {
 
     private String listAllNpcs(Map<String, NpcInfo> npcInfos) {
         JsonObject result = new JsonObject();
-        result.addProperty("npc_count", npcInfos.size());
+        Json.put(result, "npc_count", npcInfos.size());
 
         JsonArray arr = new JsonArray();
         for (Map.Entry<String, NpcInfo> entry : npcInfos.entrySet()) {
             JsonObject item = new JsonObject();
-            item.addProperty("name", entry.getKey());
+            Json.put(item, "name", entry.getKey());
 
             NpcInfo info = entry.getValue();
             if (info != null) {
                 Json.put(item, "should_kill", info.getShouldKill());
-                item.addProperty("priority", info.getPriority());
-                item.addProperty("radius", info.getRadius());
+                Json.put(item, "priority", info.getPriority());
+                Json.put(item, "radius", info.getRadius());
                 if (info.getAmmo().isPresent()) {
-                    item.addProperty("ammo", info.getAmmo().get().getId());
+                    Json.put(item, "ammo", info.getAmmo().get().getId());
                 }
                 if (info.getFormation().isPresent()) {
-                    item.addProperty("formation", info.getFormation().get().getId());
+                    Json.put(item, "formation", info.getFormation().get().getId());
                 }
             }
 
@@ -92,25 +92,25 @@ public class NpcConfigResource implements McpResource {
         NpcInfo info = npcInfos.get(npcName);
 
         JsonObject result = new JsonObject();
-        result.addProperty("name", npcName);
+        Json.put(result, "name", npcName);
 
         if (info == null) {
             Json.put(result, "configured", false);
-            result.addProperty("message", "NPC not found in configuration. Create it in DarkBot's UI first.");
+            Json.put(result, "message", "NPC not found in configuration. Create it in DarkBot's UI first.");
             return gson.toJson(result);
         }
 
         Json.put(result, "configured", true);
         Json.put(result, "should_kill", info.getShouldKill());
-        result.addProperty("priority", info.getPriority());
-        result.addProperty("radius", info.getRadius());
+        Json.put(result, "priority", info.getPriority());
+        Json.put(result, "radius", info.getRadius());
 
         info.getAmmo().ifPresent(ammo -> {
-            result.addProperty("ammo", ammo.getId());
+            Json.put(result, "ammo", ammo.getId());
         });
 
         info.getFormation().ifPresent(formation -> {
-            result.addProperty("formation", formation.getId());
+            Json.put(result, "formation", formation.getId());
         });
 
         result.add("map_ids", gson.toJsonTree(info.getMapIds()));

--- a/src/main/java/com/deeme/tasks/mcp/resources/NpcEventResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/NpcEventResource.java
@@ -51,14 +51,14 @@ public class NpcEventResource implements McpResource {
         }
         Json.put(o, "available", true);
         if (ev.getStatus() != null)
-            o.addProperty("status", ev.getStatus().name());
+            Json.put(o, "status", ev.getStatus().name());
         Json.put(o, "remaining_seconds", Math.round(ev.getRemainingTime() * 100.0) / 100.0);
         if (ev.getEventName() != null)
-            o.addProperty("name", ev.getEventName());
+            Json.put(o, "name", ev.getEventName());
         if (ev.getEventId() != null)
-            o.addProperty("event_id", ev.getEventId());
+            Json.put(o, "event_id", ev.getEventId());
         if (ev.getEventDescription() != null)
-            o.addProperty("description", ev.getEventDescription());
+            Json.put(o, "description", ev.getEventDescription());
         Json.put(o, "npc_left", ev.npcLeft());
         Json.put(o, "boss_npc_left", ev.bossNpcLeft());
         return o;

--- a/src/main/java/com/deeme/tasks/mcp/resources/OreResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/OreResource.java
@@ -44,7 +44,7 @@ public class OreResource implements McpResource {
         JsonArray oreArr = new JsonArray();
         for (OreAPI.Ore ore : OreAPI.Ore.values()) {
             JsonObject o = new JsonObject();
-            o.addProperty("ore", ore.getName());
+            Json.put(o, "ore", ore.getName());
             Json.put(o, "amount", ores.getAmount(ore));
             Json.put(o, "sellable", ore.isSellable());
             Json.put(o, "upgradable", ore.isUpgradable());
@@ -55,11 +55,11 @@ public class OreResource implements McpResource {
         JsonArray upArr = new JsonArray();
         for (OreAPI.UpgradeSlot slot : OreAPI.UpgradeSlot.values()) {
             JsonObject o = new JsonObject();
-            o.addProperty("slot", slot.name());
+            Json.put(o, "slot", slot.name());
             OreAPI.Upgrade up = ores.getUpgrade(slot);
             if (up != null) {
                 if (up.getOre() != null)
-                    o.addProperty("ore", up.getOre().getName());
+                    Json.put(o, "ore", up.getOre().getName());
                 Json.put(o, "amount", up.getAmount());
             }
             upArr.add(o);

--- a/src/main/java/com/deeme/tasks/mcp/resources/PeekResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/PeekResource.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.resources;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -35,6 +37,8 @@ import java.util.Optional;
  */
 public class PeekResource implements McpResource {
 
+    private static final String ERROR_KEY = "error";
+
     private static final String MAIN_CLASS = "com.github.manolo8.darkbot.Main";
     private static final String IDARK_BOT_API_CLASS = "com.github.manolo8.darkbot.core.IDarkBotAPI";
     private static final String BYTE_UTILS_CLASS = "com.github.manolo8.darkbot.core.utils.ByteUtils";
@@ -68,15 +72,15 @@ public class PeekResource implements McpResource {
         Map<String, String> params = parseQuery(uri);
         Optional<Long> parsed = parseAddress(params.get("address"));
         if (!parsed.isPresent()) {
-            result.addProperty("error", "Missing or invalid 'address'");
+            Json.put(result, ERROR_KEY, "Missing or invalid 'address'");
             return gson.toJson(result);
         }
         long address = parsed.get();
-        result.addProperty("address", String.format("0x%x", address));
+        Json.put(result, "address", String.format("0x%x", address));
 
         String offsets = params.get("offsets");
         if (offsets == null || offsets.isEmpty() || resolved == null) {
-            result.addProperty("error",
+            Json.put(result, ERROR_KEY,
                     offsets == null || offsets.isEmpty()
                             ? "Missing 'offsets' (e.g. 40:int;56:int)"
                             : "DarkBot API not reachable");
@@ -93,7 +97,10 @@ public class PeekResource implements McpResource {
 
     private JsonObject readOne(String spec, long base) {
         JsonObject out = new JsonObject();
-        out.addProperty("spec", spec);
+        if (spec == null || spec.trim().isEmpty()) {
+            return error(out, "Missing spec, use offset:type");
+        }
+        Json.put(out, "spec", spec);
         String[] parts = spec.split(":");
         if (parts.length != 2) {
             return error(out, "Bad spec, use offset:type");
@@ -153,7 +160,7 @@ public class PeekResource implements McpResource {
     }
 
     private JsonObject error(JsonObject out, String message) {
-        out.addProperty("error", message);
+        Json.put(out, ERROR_KEY, message);
         return out;
     }
 

--- a/src/main/java/com/deeme/tasks/mcp/resources/PetResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/PetResource.java
@@ -48,8 +48,8 @@ public class PetResource implements McpResource {
 
         PetGear gear = pet.getGear();
         if (gear != null) {
-            obj.addProperty("gear_id", gear.getId());
-            obj.addProperty("gear_name", gear.getName());
+            Json.put(obj, "gear_id", gear.getId());
+            Json.put(obj, "gear_name", gear.getName());
         }
 
         pet.getLocatorNpcLoc().ifPresent(loc -> {

--- a/src/main/java/com/deeme/tasks/mcp/resources/PluginResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/PluginResource.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.resources;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -38,10 +40,10 @@ public class PluginResource implements McpResource {
         JsonArray loaded = new JsonArray();
         for (PluginInfo pl : extensions.getPluginInfos()) {
             JsonObject p = new JsonObject();
-            p.addProperty("name", pl.getName());
-            p.addProperty("author", pl.getAuthor());
+            Json.put(p, "name", pl.getName());
+            Json.put(p, "author", pl.getAuthor());
             if (pl.getVersion() != null)
-                p.addProperty("version", pl.getVersion().toString());
+                Json.put(p, "version", pl.getVersion().toString());
             loaded.add(p);
         }
         obj.add("loaded", loaded);

--- a/src/main/java/com/deeme/tasks/mcp/resources/ProfileListResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/ProfileListResource.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.resources;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -43,7 +45,7 @@ public class ProfileListResource implements McpResource {
 
         JsonObject result = new JsonObject();
         result.add("profiles", arr);
-        result.addProperty("count", profiles.size());
+        Json.put(result, "count", profiles.size());
         return gson.toJson(result);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/resources/RepairResource.java
+++ b/src/main/java/com/deeme/tasks/mcp/resources/RepairResource.java
@@ -44,10 +44,10 @@ public class RepairResource implements McpResource {
 
         String destroyer = repair.getLastDestroyerName();
         if (destroyer != null)
-            obj.addProperty("last_destroyer", destroyer);
+            Json.put(obj, "last_destroyer", destroyer);
 
         if (repair.getLastDeathTime() != null) {
-            obj.addProperty("last_death_time", repair.getLastDeathTime().toString());
+            Json.put(obj, "last_death_time", repair.getLastDeathTime().toString());
             Json.put(obj, "last_death_epoch", repair.getLastDeathTime().getEpochSecond());
         }
 

--- a/src/main/java/com/deeme/tasks/mcp/server/McpProtocol.java
+++ b/src/main/java/com/deeme/tasks/mcp/server/McpProtocol.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.server;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.*;
 
 import com.deeme.tasks.mcp.resources.McpResource;
@@ -12,6 +14,7 @@ import java.util.function.Consumer;
 public class McpProtocol {
 
     private static final String PROTOCOL_VERSION = "2025-03-26";
+    private static final String JSONRPC_KEY = "jsonrpc";
 
     private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
     private final Map<String, McpResource> resources = new LinkedHashMap<>();
@@ -49,10 +52,10 @@ public class McpProtocol {
 
     public void notifyResourceUpdated(String uri) {
         JsonObject params = new JsonObject();
-        params.addProperty("uri", uri);
+        Json.put(params, "uri", uri);
         JsonObject notif = new JsonObject();
-        notif.addProperty("jsonrpc", "2.0");
-        notif.addProperty("method", "notifications/resources/updated");
+        Json.put(notif, JSONRPC_KEY, "2.0");
+        Json.put(notif, "method", "notifications/resources/updated");
         notif.add("params", params);
         broadcaster.accept(gson.toJson(notif));
     }
@@ -60,7 +63,7 @@ public class McpProtocol {
     public String handleMessage(String json) {
         try {
             JsonObject msg = gson.fromJson(json, JsonObject.class);
-            if (msg == null || !"2.0".equals(getString(msg, "jsonrpc")))
+            if (msg == null || !"2.0".equals(getString(msg, JSONRPC_KEY)))
                 return jsonRpcError(null, -32600, "Invalid Request: not valid JSON-RPC 2.0");
 
             String method = getString(msg, "method");
@@ -125,11 +128,11 @@ public class McpProtocol {
         caps.add("tools", toolCaps);
 
         JsonObject serverInfo = new JsonObject();
-        serverInfo.addProperty("name", serverName);
-        serverInfo.addProperty("version", serverVersion);
+        Json.put(serverInfo, "name", serverName);
+        Json.put(serverInfo, "version", serverVersion);
 
         JsonObject result = new JsonObject();
-        result.addProperty("protocolVersion", PROTOCOL_VERSION);
+        Json.put(result, "protocolVersion", PROTOCOL_VERSION);
         result.add("capabilities", caps);
         result.add("serverInfo", serverInfo);
         return jsonRpcResult(id, result);
@@ -139,11 +142,11 @@ public class McpProtocol {
         JsonArray arr = new JsonArray();
         for (McpResource res : resources.values()) {
             JsonObject r = new JsonObject();
-            r.addProperty("uri", res.getUri());
-            r.addProperty("name", res.getName());
-            r.addProperty("description", res.getDescription());
+            Json.put(r, "uri", res.getUri());
+            Json.put(r, "name", res.getName());
+            Json.put(r, "description", res.getDescription());
             if (res.getMimeType() != null)
-                r.addProperty("mimeType", res.getMimeType());
+                Json.put(r, "mimeType", res.getMimeType());
             arr.add(r);
         }
         JsonObject result = new JsonObject();
@@ -164,10 +167,10 @@ public class McpProtocol {
             return jsonRpcError(id, -32602, "Resource not found: " + uri);
 
         JsonObject content = new JsonObject();
-        content.addProperty("uri", uri);
+        Json.put(content, "uri", uri);
         if (res.getMimeType() != null)
-            content.addProperty("mimeType", res.getMimeType());
-        content.addProperty("text", res.read(uri));
+            Json.put(content, "mimeType", res.getMimeType());
+        Json.put(content, "text", res.read(uri));
 
         JsonArray contents = new JsonArray();
         contents.add(content);
@@ -224,8 +227,8 @@ public class McpProtocol {
         JsonArray arr = new JsonArray();
         for (McpTool tool : tools.values()) {
             JsonObject t = new JsonObject();
-            t.addProperty("name", tool.getName());
-            t.addProperty("description", tool.getDescription());
+            Json.put(t, "name", tool.getName());
+            Json.put(t, "description", tool.getDescription());
             t.add("inputSchema", tool.getInputSchema());
             arr.add(t);
         }
@@ -259,8 +262,8 @@ public class McpProtocol {
             String result = tool.call(argMap);
             JsonArray contents = new JsonArray();
             JsonObject content = new JsonObject();
-            content.addProperty("type", "text");
-            content.addProperty("text", result);
+            Json.put(content, "type", "text");
+            Json.put(content, "text", result);
             contents.add(content);
 
             JsonObject res = new JsonObject();
@@ -273,7 +276,7 @@ public class McpProtocol {
 
     private String jsonRpcResult(String id, JsonObject result) {
         JsonObject msg = new JsonObject();
-        msg.addProperty("jsonrpc", "2.0");
+        Json.put(msg, JSONRPC_KEY, "2.0");
         msg.add("result", result);
         if (id != null)
             msg.add("id", parseJson(id));
@@ -282,11 +285,11 @@ public class McpProtocol {
 
     private String jsonRpcError(String id, int code, String message) {
         JsonObject error = new JsonObject();
-        error.addProperty("code", code);
-        error.addProperty("message", message);
+        Json.put(error, "code", code);
+        Json.put(error, "message", message);
 
         JsonObject msg = new JsonObject();
-        msg.addProperty("jsonrpc", "2.0");
+        Json.put(msg, JSONRPC_KEY, "2.0");
         msg.add("error", error);
         if (id != null)
             msg.add("id", parseJson(id));

--- a/src/main/java/com/deeme/tasks/mcp/tools/AttackEntityTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/AttackEntityTool.java
@@ -63,20 +63,20 @@ public class AttackEntityTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject actionProp = new JsonObject();
-        actionProp.addProperty("type", "string");
-        actionProp.addProperty("description", "'attack' (default) to hunt entity_id, or 'stop' to abort.");
+        Json.put(actionProp, "type", "string");
+        Json.put(actionProp, "description", "'attack' (default) to hunt entity_id, or 'stop' to abort.");
         JsonArray actionEnum = new JsonArray();
         actionEnum.add(new JsonPrimitive(ACTION_ATTACK));
         actionEnum.add(new JsonPrimitive(ACTION_STOP));
         actionProp.add("enum", actionEnum);
 
         JsonObject idProp = new JsonObject();
-        idProp.addProperty("type", "integer");
-        idProp.addProperty("description", "Entity id to attack (from mcp://entities). Required for 'attack'.");
+        Json.put(idProp, "type", "integer");
+        Json.put(idProp, "description", "Entity id to attack (from mcp://entities). Required for 'attack'.");
 
         JsonObject timeoutProp = new JsonObject();
-        timeoutProp.addProperty("type", "integer");
-        timeoutProp.addProperty("description",
+        Json.put(timeoutProp, "type", "integer");
+        Json.put(timeoutProp, "description",
                 "Max seconds to chase the target before giving up (default 120, 0 = no timeout, max 1800).");
 
         JsonObject props = new JsonObject();
@@ -85,7 +85,7 @@ public class AttackEntityTool implements McpTool {
         props.add("timeout_seconds", timeoutProp);
 
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", props);
         return schema;
     }
@@ -118,20 +118,20 @@ public class AttackEntityTool implements McpTool {
         bot.setModule(module);
 
         JsonObject result = new JsonObject();
-        result.addProperty("action", ACTION_ATTACK);
+        Json.put(result, "action", ACTION_ATTACK);
         Json.put(result, "entity_id", id);
-        result.addProperty("entity_type", typeOf(found));
+        Json.put(result, "entity_type", typeOf(found));
         Json.put(result, "timeout_seconds", timeout);
-        result.addProperty("status", "hunting");
+        Json.put(result, "status", "hunting");
         return gson.toJson(result);
     }
 
     private String stopAttack() {
         boolean wasHunter = abortCurrentHunter();
         JsonObject result = new JsonObject();
-        result.addProperty("action", ACTION_STOP);
+        Json.put(result, "action", ACTION_STOP);
         Json.put(result, "was_hunting", wasHunter);
-        result.addProperty("status", wasHunter ? "aborted" : "idle");
+        Json.put(result, "status", wasHunter ? "aborted" : "idle");
         return gson.toJson(result);
     }
 
@@ -208,7 +208,7 @@ public class AttackEntityTool implements McpTool {
 
     private String error(String message) {
         JsonObject err = new JsonObject();
-        err.addProperty("error", message);
+        Json.put(err, "error", message);
         return gson.toJson(err);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/tools/BotControlTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/BotControlTool.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.tools;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.JsonObject;
 import eu.darkbot.api.managers.BotAPI;
 
@@ -26,7 +28,7 @@ public class BotControlTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", new JsonObject());
         return schema;
     }
@@ -36,8 +38,8 @@ public class BotControlTool implements McpTool {
         boolean wasRunning = bot.isRunning();
         bot.setRunning(!wasRunning);
         JsonObject result = new JsonObject();
-        result.addProperty("previous_state", wasRunning ? "running" : "paused");
-        result.addProperty("current_state", bot.isRunning() ? "running" : "paused");
+        Json.put(result, "previous_state", wasRunning ? "running" : "paused");
+        Json.put(result, "current_state", bot.isRunning() ? "running" : "paused");
         return result.toString();
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/tools/BuildConditionTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/BuildConditionTool.java
@@ -30,13 +30,13 @@ public class BuildConditionTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject conditionProp = new JsonObject();
-        conditionProp.addProperty("type", "object");
-        conditionProp.addProperty("description",
+        Json.put(conditionProp, "type", "object");
+        Json.put(conditionProp, "description",
                 "Condition tree node with 'type' and type-specific fields. " +
                         "See conditions://schema for all types, parameters, and enum values.");
         JsonObject typeProp = new JsonObject();
-        typeProp.addProperty("type", "string");
-        typeProp.addProperty("description",
+        Json.put(typeProp, "type", "string");
+        Json.put(typeProp, "description",
                 "Condition type: all, any, none, one, if, equal, has-effect, " +
                         "has-formation, has-relation, has-quest, after, until, boolean");
         conditionProp.add("properties", new JsonObject());
@@ -49,21 +49,21 @@ public class BuildConditionTool implements McpTool {
         JsonArray examples = new JsonArray();
 
         JsonObject ex1 = new JsonObject();
-        ex1.addProperty("condition",
+        Json.put(ex1, "condition",
                 "{\"type\":\"all\",\"children\":[{\"type\":\"has-quest\"},{\"type\":\"if\"," +
                         "\"a\":{\"type\":\"health\",\"ship\":{\"type\":\"hero\"}},\"operation\":\">\"," +
                         "\"b\":{\"type\":\"number\",\"value\":5000}}]}");
         examples.add(ex1);
 
         JsonObject ex2 = new JsonObject();
-        ex2.addProperty("condition",
+        Json.put(ex2, "condition",
                 "{\"type\":\"any\",\"children\":[" +
                         "{\"type\":\"has-effect\",\"effect\":\"singularity\",\"ship\":{\"type\":\"target\"}}," +
                         "{\"type\":\"has-formation\",\"formation\":\"chevron\",\"ship\":{\"type\":\"hero\"}}]}");
         examples.add(ex2);
 
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", props);
         JsonArray required = new JsonArray();
         required.add(new JsonPrimitive("condition"));
@@ -89,7 +89,7 @@ public class BuildConditionTool implements McpTool {
         try {
             String dsl = buildNode(condition);
             JsonObject result = new JsonObject();
-            result.addProperty("condition", dsl);
+            Json.put(result, "condition", dsl);
             Json.put(result, "valid", true);
             return GSON.toJson(result);
         } catch (Exception e) {
@@ -266,7 +266,7 @@ public class BuildConditionTool implements McpTool {
     private String error(String message) {
         JsonObject err = new JsonObject();
         Json.put(err, "valid", false);
-        err.addProperty("error", message);
+        Json.put(err, "error", message);
         return GSON.toJson(err);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/tools/MoveToTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/MoveToTool.java
@@ -36,8 +36,8 @@ public class MoveToTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject actionProp = new JsonObject();
-        actionProp.addProperty("type", "string");
-        actionProp.addProperty("description", "Movement action.");
+        Json.put(actionProp, "type", "string");
+        Json.put(actionProp, "description", "Movement action.");
         com.google.gson.JsonArray actionEnum = new com.google.gson.JsonArray();
         actionEnum.add(new com.google.gson.JsonPrimitive("goto"));
         actionEnum.add(new com.google.gson.JsonPrimitive("random"));
@@ -45,16 +45,16 @@ public class MoveToTool implements McpTool {
         actionProp.add("enum", actionEnum);
 
         JsonObject xProp = new JsonObject();
-        xProp.addProperty("type", "number");
-        xProp.addProperty("description", "Target X coordinate. Required for 'goto'.");
+        Json.put(xProp, "type", "number");
+        Json.put(xProp, "description", "Target X coordinate. Required for 'goto'.");
 
         JsonObject yProp = new JsonObject();
-        yProp.addProperty("type", "number");
-        yProp.addProperty("description", "Target Y coordinate. Required for 'goto'.");
+        Json.put(yProp, "type", "number");
+        Json.put(yProp, "description", "Target Y coordinate. Required for 'goto'.");
 
         JsonObject stopHardProp = new JsonObject();
-        stopHardProp.addProperty("type", "boolean");
-        stopHardProp.addProperty("description", "For 'stop': true to hard-stop in current location (default false).");
+        Json.put(stopHardProp, "type", "boolean");
+        Json.put(stopHardProp, "description", "For 'stop': true to hard-stop in current location (default false).");
 
         JsonObject props = new JsonObject();
         props.add("action", actionProp);
@@ -63,7 +63,7 @@ public class MoveToTool implements McpTool {
         props.add("stop_hard", stopHardProp);
 
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", props);
         com.google.gson.JsonArray required = new com.google.gson.JsonArray();
         required.add(new com.google.gson.JsonPrimitive("action"));
@@ -107,7 +107,7 @@ public class MoveToTool implements McpTool {
 
     private String resultJson(String action, Double x, Double y) {
         JsonObject o = new JsonObject();
-        o.addProperty("action", action);
+        Json.put(o, "action", action);
         if (x != null) Json.put(o, "x", Math.round(x * 100.0) / 100.0);
         if (y != null) Json.put(o, "y", Math.round(y * 100.0) / 100.0);
         JsonObject dest = new JsonObject();
@@ -125,7 +125,7 @@ public class MoveToTool implements McpTool {
 
     private String error(String message) {
         JsonObject err = new JsonObject();
-        err.addProperty("error", message);
+        Json.put(err, "error", message);
         return gson.toJson(err);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/tools/PluginReloadTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/PluginReloadTool.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.tools;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -33,7 +35,7 @@ public class PluginReloadTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", new JsonObject());
         return schema;
     }
@@ -53,12 +55,12 @@ public class PluginReloadTool implements McpTool {
 
             JsonObject result = new JsonObject();
             result.add("success", new JsonPrimitive(true));
-            result.addProperty("message", "Plugin reload triggered successfully");
+            Json.put(result, "message", "Plugin reload triggered successfully");
             return gson.toJson(result);
         } catch (Throwable e) {
             JsonObject result = new JsonObject();
             result.add("success", new JsonPrimitive(false));
-            result.addProperty("error", "Failed to reload plugins: " + e.getMessage());
+            Json.put(result, "error", "Failed to reload plugins: " + e.getMessage());
             return gson.toJson(result);
         }
     }

--- a/src/main/java/com/deeme/tasks/mcp/tools/ResetDeathsTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/ResetDeathsTool.java
@@ -35,7 +35,7 @@ public class ResetDeathsTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", new JsonObject());
         return schema;
     }

--- a/src/main/java/com/deeme/tasks/mcp/tools/ResourceTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/ResourceTool.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.tools;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -11,6 +13,8 @@ import com.deeme.tasks.mcp.resources.McpResource;
 import java.util.Map;
 
 public class ResourceTool implements McpTool {
+
+    private static final String DESCRIPTION_KEY = "description";
 
     private final Map<String, McpResource> resources;
     private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
@@ -34,13 +38,13 @@ public class ResourceTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
 
         JsonObject props = new JsonObject();
 
         JsonObject actionProp = new JsonObject();
-        actionProp.addProperty("type", "string");
-        actionProp.addProperty("description", "Action: 'list' to enumerate resources, 'read' to get a resource by URI");
+        Json.put(actionProp, "type", "string");
+        Json.put(actionProp, DESCRIPTION_KEY, "Action: 'list' to enumerate resources, 'read' to get a resource by URI");
         JsonArray enum_ = new JsonArray();
         enum_.add(new JsonPrimitive("list"));
         enum_.add(new JsonPrimitive("read"));
@@ -48,8 +52,8 @@ public class ResourceTool implements McpTool {
         props.add("action", actionProp);
 
         JsonObject uriProp = new JsonObject();
-        uriProp.addProperty("type", "string");
-        uriProp.addProperty("description", "Resource URI to read (required when action is 'read')");
+        Json.put(uriProp, "type", "string");
+        Json.put(uriProp, DESCRIPTION_KEY, "Resource URI to read (required when action is 'read')");
         props.add("uri", uriProp);
 
         schema.add("properties", props);
@@ -85,11 +89,11 @@ public class ResourceTool implements McpTool {
         JsonArray arr = new JsonArray();
         for (McpResource res : resources.values()) {
             JsonObject r = new JsonObject();
-            r.addProperty("uri", res.getUri());
-            r.addProperty("name", res.getName());
-            r.addProperty("description", res.getDescription());
+            Json.put(r, "uri", res.getUri());
+            Json.put(r, "name", res.getName());
+            Json.put(r, DESCRIPTION_KEY, res.getDescription());
             if (res.getMimeType() != null)
-                r.addProperty("mimeType", res.getMimeType());
+                Json.put(r, "mimeType", res.getMimeType());
             arr.add(r);
         }
         JsonObject result = new JsonObject();

--- a/src/main/java/com/deeme/tasks/mcp/tools/SetConfigTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/SetConfigTool.java
@@ -1,5 +1,7 @@
 package com.deeme.tasks.mcp.tools;
 
+import com.deeme.tasks.mcp.util.Json;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -33,18 +35,18 @@ public class SetConfigTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject pathProp = new JsonObject();
-        pathProp.addProperty("type", "string");
-        pathProp.addProperty("description", "Dot-separated config path (e.g. general.working_map).");
+        Json.put(pathProp, "type", "string");
+        Json.put(pathProp, "description", "Dot-separated config path (e.g. general.working_map).");
 
         JsonObject valueProp = new JsonObject();
-        valueProp.addProperty("description", "New value for the setting (boolean, number or string).");
+        Json.put(valueProp, "description", "New value for the setting (boolean, number or string).");
 
         JsonObject props = new JsonObject();
         props.add("path", pathProp);
         props.add("value", valueProp);
 
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", props);
         JsonArray required = new JsonArray();
         required.add(new JsonPrimitive("path"));
@@ -76,8 +78,8 @@ public class SetConfigTool implements McpTool {
         setting.setValue(converted);
 
         JsonObject result = new JsonObject();
-        result.addProperty("path", path);
-        result.addProperty("type", setting.getType().getSimpleName());
+        Json.put(result, "path", path);
+        Json.put(result, "type", setting.getType().getSimpleName());
         result.add("previous_value", gson.toJsonTree(previous));
         result.add("new_value", gson.toJsonTree(converted));
         return gson.toJson(result);
@@ -116,7 +118,7 @@ public class SetConfigTool implements McpTool {
 
     private String error(String message) {
         JsonObject err = new JsonObject();
-        err.addProperty("error", message);
+        Json.put(err, "error", message);
         return gson.toJson(err);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/tools/SetNpcConfigTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/SetNpcConfigTool.java
@@ -36,28 +36,28 @@ public class SetNpcConfigTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject nameProp = new JsonObject();
-        nameProp.addProperty("type", "string");
-        nameProp.addProperty("description", "NPC name to configure.");
+        Json.put(nameProp, "type", "string");
+        Json.put(nameProp, "description", "NPC name to configure.");
 
         JsonObject actionProp = new JsonObject();
-        actionProp.addProperty("type", "string");
-        actionProp.addProperty("description", "Action: 'set' (default) or 'remove'.");
+        Json.put(actionProp, "type", "string");
+        Json.put(actionProp, "description", "Action: 'set' (default) or 'remove'.");
         JsonArray actionEnum = new JsonArray();
         actionEnum.add(new JsonPrimitive("set"));
         actionEnum.add(new JsonPrimitive("remove"));
         actionProp.add("enum", actionEnum);
 
         JsonObject shouldKillProp = new JsonObject();
-        shouldKillProp.addProperty("type", "boolean");
-        shouldKillProp.addProperty("description", "Whether to kill this NPC.");
+        Json.put(shouldKillProp, "type", "boolean");
+        Json.put(shouldKillProp, "description", "Whether to kill this NPC.");
 
         JsonObject priorityProp = new JsonObject();
-        priorityProp.addProperty("type", "integer");
-        priorityProp.addProperty("description", "Priority (lower = more important).");
+        Json.put(priorityProp, "type", "integer");
+        Json.put(priorityProp, "description", "Priority (lower = more important).");
 
         JsonObject radiusProp = new JsonObject();
-        radiusProp.addProperty("type", "number");
-        radiusProp.addProperty("description", "Distance to stand from NPC.");
+        Json.put(radiusProp, "type", "number");
+        Json.put(radiusProp, "description", "Distance to stand from NPC.");
 
         JsonObject props = new JsonObject();
         props.add("name", nameProp);
@@ -67,7 +67,7 @@ public class SetNpcConfigTool implements McpTool {
         props.add("radius", radiusProp);
 
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", props);
 
         JsonArray required = new JsonArray();
@@ -132,17 +132,17 @@ public class SetNpcConfigTool implements McpTool {
         configSetting.setValue(npcInfos);
 
         JsonObject result = new JsonObject();
-        result.addProperty("npc_name", npcName);
-        result.addProperty("action", "updated");
+        Json.put(result, "npc_name", npcName);
+        Json.put(result, "action", "updated");
 
         if (args.containsKey("should_kill")) {
             Json.put(result, "should_kill", Boolean.parseBoolean(String.valueOf(args.get("should_kill"))));
         }
         if (args.containsKey("priority")) {
-            result.addProperty("priority", parseNumber(args.get("priority")).intValue());
+            Json.put(result, "priority", parseNumber(args.get("priority")).intValue());
         }
         if (args.containsKey("radius")) {
-            result.addProperty("radius", parseNumber(args.get("radius")).doubleValue());
+            Json.put(result, "radius", parseNumber(args.get("radius")).doubleValue());
         }
 
         return gson.toJson(result);
@@ -154,17 +154,17 @@ public class SetNpcConfigTool implements McpTool {
 
         if (removed == null) {
             JsonObject result = new JsonObject();
-            result.addProperty("npc_name", npcName);
-            result.addProperty("action", "not_found");
-            result.addProperty("message", "NPC was not configured");
+            Json.put(result, "npc_name", npcName);
+            Json.put(result, "action", "not_found");
+            Json.put(result, "message", "NPC was not configured");
             return gson.toJson(result);
         }
 
         configSetting.setValue(npcInfos);
 
         JsonObject result = new JsonObject();
-        result.addProperty("npc_name", npcName);
-        result.addProperty("action", "removed");
+        Json.put(result, "npc_name", npcName);
+        Json.put(result, "action", "removed");
         return gson.toJson(result);
     }
 
@@ -176,7 +176,7 @@ public class SetNpcConfigTool implements McpTool {
 
     private String error(String message) {
         JsonObject err = new JsonObject();
-        err.addProperty("error", message);
+        Json.put(err, "error", message);
         return gson.toJson(err);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/tools/SetPetGearTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/SetPetGearTool.java
@@ -41,12 +41,12 @@ public class SetPetGearTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject enabledProp = new JsonObject();
-        enabledProp.addProperty("type", "boolean");
-        enabledProp.addProperty("description", "true to enable PET, false to disable.");
+        Json.put(enabledProp, "type", "boolean");
+        Json.put(enabledProp, "description", "true to enable PET, false to disable.");
 
         JsonObject gearProp = new JsonObject();
-        gearProp.addProperty("type", "string");
-        gearProp.addProperty("description", "PetGear enum name. Pass null/empty to reset to user-configured gear.");
+        Json.put(gearProp, "type", "string");
+        Json.put(gearProp, "description", "PetGear enum name. Pass null/empty to reset to user-configured gear.");
         JsonArray gearEnum = new JsonArray();
         for (PetGear g : PetGear.values()) {
             gearEnum.add(new JsonPrimitive(g.name()));
@@ -58,7 +58,7 @@ public class SetPetGearTool implements McpTool {
         props.add("gear", gearProp);
 
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", props);
         return schema;
     }
@@ -102,10 +102,10 @@ public class SetPetGearTool implements McpTool {
         Json.put(result, "previous_enabled", prevEnabled);
         Json.put(result, "current_enabled", pet.isEnabled());
         if (prevGear != null) {
-            result.addProperty("previous_gear", prevGear.name());
+            Json.put(result, "previous_gear", prevGear.name());
         }
         if (pet.getGear() != null) {
-            result.addProperty("current_gear", pet.getGear().name());
+            Json.put(result, "current_gear", pet.getGear().name());
         }
         return gson.toJson(result);
     }
@@ -116,7 +116,7 @@ public class SetPetGearTool implements McpTool {
 
     private String error(String message) {
         JsonObject err = new JsonObject();
-        err.addProperty("error", message);
+        Json.put(err, "error", message);
         return gson.toJson(err);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/tools/SetProfileTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/SetProfileTool.java
@@ -33,14 +33,14 @@ public class SetProfileTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject profileProp = new JsonObject();
-        profileProp.addProperty("type", "string");
-        profileProp.addProperty("description", "Name of the config profile to switch to.");
+        Json.put(profileProp, "type", "string");
+        Json.put(profileProp, "description", "Name of the config profile to switch to.");
 
         JsonObject props = new JsonObject();
         props.add("profile", profileProp);
 
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", props);
         JsonArray required = new JsonArray();
         required.add(new JsonPrimitive("profile"));
@@ -61,14 +61,14 @@ public class SetProfileTool implements McpTool {
         configAPI.setConfigProfile(profile);
 
         JsonObject result = new JsonObject();
-        result.addProperty("profile", profile);
+        Json.put(result, "profile", profile);
         Json.put(result, "success", true);
         return gson.toJson(result);
     }
 
     private String error(String message) {
         JsonObject err = new JsonObject();
-        err.addProperty("error", message);
+        Json.put(err, "error", message);
         return gson.toJson(err);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/tools/ValidateConditionTool.java
+++ b/src/main/java/com/deeme/tasks/mcp/tools/ValidateConditionTool.java
@@ -33,8 +33,8 @@ public class ValidateConditionTool implements McpTool {
     @Override
     public JsonObject getInputSchema() {
         JsonObject conditionProp = new JsonObject();
-        conditionProp.addProperty("type", "string");
-        conditionProp.addProperty("description",
+        Json.put(conditionProp, "type", "string");
+        Json.put(conditionProp, "description",
                 "The condition DSL string to validate. " +
                         "Examples: 'all(has-quest(), if(health(hero()) > number(5000)))', " +
                         "'any(has-effect(singularity, target()), has-formation(chevron, hero()))'");
@@ -43,7 +43,7 @@ public class ValidateConditionTool implements McpTool {
         props.add("condition", conditionProp);
 
         JsonObject schema = new JsonObject();
-        schema.addProperty("type", "object");
+        Json.put(schema, "type", "object");
         schema.add("properties", props);
         JsonArray required = new JsonArray();
         required.add(new JsonPrimitive("condition"));
@@ -58,19 +58,19 @@ public class ValidateConditionTool implements McpTool {
         JsonArray examples = new JsonArray();
 
         JsonObject ex1 = new JsonObject();
-        ex1.addProperty("condition", "all(has-quest(), if(health(hero()) > number(5000)))");
+        Json.put(ex1, "condition", "all(has-quest(), if(health(hero()) > number(5000)))");
         examples.add(ex1);
 
         JsonObject ex2 = new JsonObject();
-        ex2.addProperty("condition", "any(has-effect(singularity, target()), has-formation(chevron, hero()))");
+        Json.put(ex2, "condition", "any(has-effect(singularity, target()), has-formation(chevron, hero()))");
         examples.add(ex2);
 
         JsonObject ex3 = new JsonObject();
-        ex3.addProperty("condition", "after(7.5, has-quest())");
+        Json.put(ex3, "condition", "after(7.5, has-quest())");
         examples.add(ex3);
 
         JsonObject ex4 = new JsonObject();
-        ex4.addProperty("condition", "boolean(true)");
+        Json.put(ex4, "condition", "boolean(true)");
         examples.add(ex4);
 
         schema.add("_examples", examples);
@@ -98,8 +98,8 @@ public class ValidateConditionTool implements McpTool {
 
             JsonObject result = new JsonObject();
             Json.put(result, "valid", true);
-            result.addProperty("condition", condition);
-            result.addProperty("message", "Condition is valid");
+            Json.put(result, "condition", condition);
+            Json.put(result, "message", "Condition is valid");
             return GSON.toJson(result);
 
         } catch (ClassNotFoundException e) {
@@ -142,8 +142,8 @@ public class ValidateConditionTool implements McpTool {
     private String handleParseError(String condition, Throwable cause) {
         JsonObject result = new JsonObject();
         Json.put(result, "valid", false);
-        result.addProperty("condition", condition);
-        result.addProperty("error", cause.getMessage());
+        Json.put(result, "condition", condition);
+        Json.put(result, "error", cause.getMessage());
 
         if (cause.getClass().getName().equals(DARKBOT_PKG + ".SyntaxException")) {
             extractErrorDetails(cause, result);
@@ -174,7 +174,7 @@ public class ValidateConditionTool implements McpTool {
                     MethodType.methodType(String.class));
             String at = invoke(getAt, cause);
             if (at != null && !at.isEmpty()) {
-                result.addProperty("position", at);
+                Json.put(result, "position", at);
             }
 
             MethodHandle getExpected = lookup.findVirtual(causeClass, "getExpected",
@@ -210,8 +210,8 @@ public class ValidateConditionTool implements McpTool {
                             String name = invoke(getName, vd);
                             String desc = invoke(getDesc, vd);
                             JsonObject s = new JsonObject();
-                            s.addProperty("name", name);
-                            s.addProperty("description", desc);
+                            Json.put(s, "name", name);
+                            Json.put(s, "description", desc);
                             suggestions.add(s);
                         } catch (Exception ignored) {
                         }
@@ -228,7 +228,7 @@ public class ValidateConditionTool implements McpTool {
     private String error(String message) {
         JsonObject err = new JsonObject();
         Json.put(err, "valid", false);
-        err.addProperty("error", message);
+        Json.put(err, "error", message);
         return GSON.toJson(err);
     }
 }

--- a/src/main/java/com/deeme/tasks/mcp/util/Json.java
+++ b/src/main/java/com/deeme/tasks/mcp/util/Json.java
@@ -2,12 +2,17 @@ package com.deeme.tasks.mcp.util;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
 public final class Json {
 
     private Json() {
+    }
+
+    public static void put(JsonObject o, String key, String value) {
+        o.add(key, value == null ? JsonNull.INSTANCE : new JsonPrimitive(value));
     }
 
     public static void put(JsonObject o, String key, boolean value) {

--- a/src/main/java/com/deeme/tasks/mcp/util/MemoryInspector.java
+++ b/src/main/java/com/deeme/tasks/mcp/util/MemoryInspector.java
@@ -50,6 +50,9 @@ public final class MemoryInspector {
 
     /** Maximum slots returned in one snapshot. Keeps payload bounded. */
     private static final int MAX_SLOTS = 256;
+    private static final String ADDRESS_KEY = "address";
+    private static final String ERROR_KEY = "error";
+    private static final String REASON_KEY = "reason";
 
     private final Resolved resolved;
 
@@ -66,23 +69,23 @@ public final class MemoryInspector {
      */
     public JsonObject inspect(String addressText) {
         JsonObject result = new JsonObject();
-        result.addProperty("root", "address");
-        result.addProperty("path", addressText == null ? "" : addressText.trim());
+        Json.put(result, "root", ADDRESS_KEY);
+        Json.put(result, "path", addressText == null ? "" : addressText.trim());
 
         Optional<Long> parsed = parseAddress(addressText);
         if (!parsed.isPresent()) {
-            result.addProperty("type", "error");
-            result.add("error", errorNode("invalid_address",
+            Json.put(result, "type", ERROR_KEY);
+            result.add(ERROR_KEY, errorNode("invalid_address",
                     "Address must be hex (0x...) or decimal, got: " + addressText));
             return result;
         }
 
         long raw = parsed.get();
-        result.addProperty("address", String.format("0x%x", raw));
+        Json.put(result, ADDRESS_KEY, String.format("0x%x", raw));
 
         if (resolved == null) {
-            result.addProperty("type", "error");
-            result.add("error", errorNode("darkbot_unavailable",
+            Json.put(result, "type", ERROR_KEY);
+            result.add(ERROR_KEY, errorNode("darkbot_unavailable",
                     "DarkBot internal classes are not reachable from this plugin"));
             return result;
         }
@@ -93,7 +96,7 @@ public final class MemoryInspector {
             if (name == null || "ERROR".equals(name)) {
                 name = "Unknown";
             }
-            result.addProperty("type", name);
+            Json.put(result, "type", name);
 
             Object slotsObj = resolved.getObjectSlots.invoke(address);
             if (!(slotsObj instanceof List)) {
@@ -127,9 +130,9 @@ public final class MemoryInspector {
         if (total > MAX_SLOTS) {
             JsonObject marker = new JsonObject();
             Json.put(marker, "truncated", true);
-            marker.addProperty("included", included);
-            marker.addProperty("total", total);
-            marker.addProperty("reason", "max_slots");
+            Json.put(marker, "included", included);
+            Json.put(marker, "total", total);
+            Json.put(marker, REASON_KEY, "max_slots");
             arr.add(marker);
         }
         return arr;
@@ -137,16 +140,16 @@ public final class MemoryInspector {
 
     private JsonElement slotToJson(Object slot, long baseAddress) throws Throwable {
         JsonObject obj = new JsonObject();
-        obj.addProperty("offset", ((Number) resolved.slotOffset.invoke(slot)).longValue());
-        obj.addProperty("name", (String) resolved.slotName.invoke(slot));
-        obj.addProperty("type", (String) resolved.slotTypeName.invoke(slot));
+        Json.put(obj, "offset", ((Number) resolved.slotOffset.invoke(slot)).longValue());
+        Json.put(obj, "name", (String) resolved.slotName.invoke(slot));
+        Json.put(obj, "type", (String) resolved.slotTypeName.invoke(slot));
         Object template = resolved.slotTemplateType.invoke(slot);
         if (template != null) {
-            obj.addProperty("template_type", template.toString());
+            Json.put(obj, "template_type", template.toString());
         }
-        obj.addProperty("size", ((Number) resolved.slotSize.invoke(slot)).longValue());
+        Json.put(obj, "size", ((Number) resolved.slotSize.invoke(slot)).longValue());
         Object typeEnum = resolved.slotType.invoke(slot);
-        obj.addProperty("slot_type", typeEnum == null ? "OBJECT" : typeEnum.toString());
+        Json.put(obj, "slot_type", typeEnum == null ? "OBJECT" : typeEnum.toString());
         obj.add("value", readSlotValue(slot, baseAddress, typeEnum));
         return obj;
     }
@@ -181,7 +184,7 @@ public final class MemoryInspector {
                     return new JsonPrimitive("null");
                 }
                 JsonObject o = new JsonObject();
-                o.addProperty("address", String.format("0x%x", ptr));
+                Json.put(o, ADDRESS_KEY, String.format("0x%x", ptr));
                 Json.put(o, "is_pointer", true);
                 return o;
             }
@@ -190,8 +193,8 @@ public final class MemoryInspector {
 
     private static JsonObject errorNode(String kind, String message) {
         JsonObject node = new JsonObject();
-        node.addProperty("error", kind);
-        node.addProperty("message", message == null ? "" : message);
+        Json.put(node, ERROR_KEY, kind);
+        Json.put(node, "message", message == null ? "" : message);
         return node;
     }
 

--- a/src/main/java/com/deeme/tasks/mcp/util/ObjectInspector.java
+++ b/src/main/java/com/deeme/tasks/mcp/util/ObjectInspector.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 
 public class ObjectInspector {
 
+    private static final String REASON_KEY = "reason";
+
     private final int maxDepth;
     private final int maxItems;
 
@@ -37,9 +39,9 @@ public class ObjectInspector {
                 .create();
 
         JsonObject result = new JsonObject();
-        result.addProperty("root", rootName);
-        result.addProperty("path", normalizePath(path));
-        result.addProperty("type", root != null ? root.getClass().getName() : "null");
+        Json.put(result, "root", rootName);
+        Json.put(result, "path", normalizePath(path));
+        Json.put(result, "type", root != null ? root.getClass().getName() : "null");
 
         try {
             JsonElement tree = gson.toJsonTree(root);
@@ -135,23 +137,23 @@ public class ObjectInspector {
     private JsonObject depthMarker(int childCount) {
         JsonObject marker = new JsonObject();
         marker.add("truncated", new JsonPrimitive(true));
-        marker.addProperty("reason", "max_depth");
-        marker.addProperty("child_count", childCount);
+        Json.put(marker, REASON_KEY, "max_depth");
+        Json.put(marker, "child_count", childCount);
         return marker;
     }
 
     private JsonObject truncationMarker(int total, int included) {
         JsonObject marker = new JsonObject();
         marker.add("truncated", new JsonPrimitive(true));
-        marker.addProperty("included", included);
-        marker.addProperty("total", total);
+        Json.put(marker, "included", included);
+        Json.put(marker, "total", total);
         return marker;
     }
 
     private JsonObject errorNode(String kind, String message) {
         JsonObject node = new JsonObject();
-        node.addProperty("kind", kind);
-        node.addProperty("message", message);
+        Json.put(node, "kind", kind);
+        Json.put(node, "message", message);
         return node;
     }
 
@@ -247,7 +249,7 @@ public class ObjectInspector {
                 private void writeMarker(JsonWriter out, Object value, String reason) throws IOException {
                     out.beginObject();
                     out.name("truncated").value(true);
-                    out.name("reason").value(reason);
+                    out.name(REASON_KEY).value(reason);
                     out.name("type").value(value.getClass().getName());
                     out.endObject();
                 }
@@ -260,7 +262,7 @@ public class ObjectInspector {
                 public void write(JsonWriter out, T value) throws IOException {
                     out.beginObject();
                     out.name("truncated").value(true);
-                    out.name("reason").value("inaccessible");
+                    out.name(REASON_KEY).value("inaccessible");
                     out.name("type").value(value != null ? value.getClass().getName() : typeName);
                     out.endObject();
                 }


### PR DESCRIPTION
## Summary
- add a null-safe `Json.put(JsonObject, String, String)` helper
- route all MCP JSON primitive writes through the existing compatibility helpers
- remove direct `JsonObject.addProperty` calls from the MCP bridge, including JSON-RPC error responses

This avoids the `NoSuchMethodError` reported on DarkBot 1.131.7 when the embedded Gson exposes `add(JsonElement)` but not the `addProperty` overloads.

## Verification
- `javac --release 11` compiles `com.deeme.tasks.mcp.util.Json` against Gson 2.8.5
- `git diff --check`
- confirmed no `.addProperty(` calls remain under `src/main/java/com/deeme/tasks/mcp`
- full Gradle build was attempted; dependency resolution is blocked by unavailable `eu.darkbot:DarkBot:97430f3417`

Closes #303

## Summary by Sourcery

Replace direct Gson JsonObject.addProperty usage across MCP server, resources, tools, and utilities with centralized Json.put helpers, including a new null-safe String overload, to maintain compatibility with embedded Gson variants that omit addProperty overloads.

New Features:
- Introduce a null-safe Json.put(JsonObject, String, String) helper for writing string JSON primitives.

Bug Fixes:
- Avoid NoSuchMethodError in environments where Gson exposes add(JsonElement) but not addProperty overloads by routing all MCP JSON primitive writes through Json.put.

Enhancements:
- Standardize JSON construction in MCP bridge, tools, and resources by using Json.put helpers for primitive fields, including JSON-RPC error responses.